### PR TITLE
RequestSummary endpoint patch

### DIFF
--- a/model/src/main/java/org/mskcc/cmo/metadb/model/web/RequestSummary.java
+++ b/model/src/main/java/org/mskcc/cmo/metadb/model/web/RequestSummary.java
@@ -1,0 +1,81 @@
+package org.mskcc.cmo.metadb.model.web;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.UUID;
+import org.neo4j.ogm.annotation.typeconversion.Convert;
+import org.neo4j.ogm.typeconversion.UuidStringConverter;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class RequestSummary implements Serializable {
+    @Convert(UuidStringConverter.class)
+    private UUID metaDbRequestId;
+    private String projectId;
+    private String requestId;
+    private String importDate;
+
+    /**
+     * RequestSummary default constructor.
+     */
+    public RequestSummary(){}
+
+    /**
+     * RequestSummary args constructor.
+     * @param metaDbRequestId
+     * @param projectId
+     * @param requestId
+     * @param importDate
+     */
+    public RequestSummary(UUID metaDbRequestId, String projectId, String requestId, String importDate) {
+        this.metaDbRequestId = metaDbRequestId;
+        this.projectId = projectId;
+        this.requestId = requestId;
+        this.importDate = importDate;
+    }
+
+    /**
+     * RequestSummary cypher query results constructor.
+     * @param values
+     */
+    public RequestSummary(List<String> values) {
+        this.metaDbRequestId = UUID.fromString(values.get(0));
+        this.projectId = values.get(1);
+        this.requestId = values.get(2);
+        this.importDate = values.get(3);
+    }
+
+    public UUID getMetaDbRequestId() {
+        return metaDbRequestId;
+    }
+
+    public void setMetaDbRequestId(UUID metaDbRequestId) {
+        this.metaDbRequestId = metaDbRequestId;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    public String getImportDate() {
+        return importDate;
+    }
+
+    public void setImportDate(String importDate) {
+        this.importDate = importDate;
+    }
+}

--- a/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/MetadbRequestRepository.java
+++ b/persistence/src/main/java/org/mskcc/cmo/metadb/persistence/MetadbRequestRepository.java
@@ -41,7 +41,7 @@ public interface MetadbRequestRepository extends Neo4jRepository<MetadbRequest, 
 
     @Query("MATCH (r:Request)-[:HAS_METADATA]->(rm:RequestMetadata) "
             + "WHERE $dateRangeStart <= [rm][0].importDate <= $dateRangeEnd "
-            + "RETURN [r.metaDbRequestId, r.requestId, [rm][0].importDate]")
+            + "RETURN [r.metaDbRequestId, r.projectId, r.requestId, [rm][0].importDate]")
     List<List<String>> findRequestWithinDateRange(@Param("dateRangeStart") String startDate,
             @Param("dateRangeEnd") String endDate);
 }

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/MetadbRequestService.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/MetadbRequestService.java
@@ -5,6 +5,7 @@ import org.mskcc.cmo.metadb.model.MetadbRequest;
 import org.mskcc.cmo.metadb.model.MetadbSample;
 import org.mskcc.cmo.metadb.model.RequestMetadata;
 import org.mskcc.cmo.metadb.model.web.PublishedMetadbRequest;
+import org.mskcc.cmo.metadb.model.web.RequestSummary;
 
 /**
  *
@@ -19,7 +20,7 @@ public interface MetadbRequestService {
     Boolean requestHasMetadataUpdates(RequestMetadata existingRequestMetadata,
             RequestMetadata requestMetadata) throws Exception;
     List<MetadbSample> getRequestSamplesWithUpdates(MetadbRequest request) throws Exception;
-    List<List<String>> getRequestsByDate(String startDate, String endDate) throws Exception;
+    List<RequestSummary> getRequestsByDate(String startDate, String endDate) throws Exception;
     List<RequestMetadata> getRequestMetadataHistory(String reqId);
     MetadbRequest getRequestBySample(MetadbSample sample) throws Exception;
 }

--- a/service/src/main/java/org/mskcc/cmo/metadb/service/impl/RequestServiceImpl.java
+++ b/service/src/main/java/org/mskcc/cmo/metadb/service/impl/RequestServiceImpl.java
@@ -24,6 +24,7 @@ import org.mskcc.cmo.metadb.model.MetadbSample;
 import org.mskcc.cmo.metadb.model.RequestMetadata;
 import org.mskcc.cmo.metadb.model.SampleMetadata;
 import org.mskcc.cmo.metadb.model.web.PublishedMetadbRequest;
+import org.mskcc.cmo.metadb.model.web.RequestSummary;
 import org.mskcc.cmo.metadb.persistence.MetadbRequestRepository;
 import org.mskcc.cmo.metadb.service.MetadbRequestService;
 import org.mskcc.cmo.metadb.service.MetadbSampleService;
@@ -244,7 +245,7 @@ public class RequestServiceImpl implements MetadbRequestService {
     }
 
     @Override
-    public List<List<String>> getRequestsByDate(String startDate, String endDate) throws Exception {
+    public List<RequestSummary> getRequestsByDate(String startDate, String endDate) throws Exception {
         if (Strings.isNullOrEmpty(startDate)) {
             throw new RuntimeException("Start date " + startDate + " cannot be null or empty");
         }
@@ -262,15 +263,8 @@ public class RequestServiceImpl implements MetadbRequestService {
             + endDate);
         }
 
-        return requestRepository.findRequestWithinDateRange(startDate, endDate);
-    }
-
-    private Date getFormattedDate(String dateString) {
-        try {
-            return new SimpleDateFormat("yyyy-MM-dd").parse(dateString);
-        } catch (ParseException e) {
-            throw new RuntimeException("Could not parse date: " + dateString, e);
-        }
+        return transformRequestSummaryResults(
+                requestRepository.findRequestWithinDateRange(startDate, endDate));
     }
 
     @Override
@@ -283,4 +277,19 @@ public class RequestServiceImpl implements MetadbRequestService {
         return requestRepository.findRequestBySample(sample);
     }
 
+    private Date getFormattedDate(String dateString) {
+        try {
+            return new SimpleDateFormat("yyyy-MM-dd").parse(dateString);
+        } catch (ParseException e) {
+            throw new RuntimeException("Could not parse date: " + dateString, e);
+        }
+    }
+
+    private List<RequestSummary> transformRequestSummaryResults(List<List<String>> results) {
+        List<RequestSummary> requestSummaryList = new ArrayList<>();
+        for (List<String> result : results) {
+            requestSummaryList.add(new RequestSummary(result));
+        }
+        return requestSummaryList;
+    }
 }

--- a/service/src/test/java/org/mskcc/cmo/metadb/service/RequestServiceTest.java
+++ b/service/src/test/java/org/mskcc/cmo/metadb/service/RequestServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.mskcc.cmo.metadb.model.MetadbRequest;
 import org.mskcc.cmo.metadb.model.MetadbSample;
 import org.mskcc.cmo.metadb.model.RequestMetadata;
+import org.mskcc.cmo.metadb.model.web.RequestSummary;
 import org.mskcc.cmo.metadb.persistence.MetadbPatientRepository;
 import org.mskcc.cmo.metadb.persistence.MetadbRequestRepository;
 import org.mskcc.cmo.metadb.persistence.MetadbSampleRepository;
@@ -214,7 +215,7 @@ public class RequestServiceTest {
     @Test
     public void testGetRequestsByNullEndDate() throws Exception {
         String startDate = "2021-10-25";
-        List<List<String>> requestDataList = requestService.getRequestsByDate(startDate, null);
+        List<RequestSummary> requestDataList = requestService.getRequestsByDate(startDate, null);
         Assertions.assertThat(requestDataList.size()).isEqualTo(3);
     }
 

--- a/web/src/main/java/org/mskcc/cmo/metadb/web/RequestController.java
+++ b/web/src/main/java/org/mskcc/cmo/metadb/web/RequestController.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.mskcc.cmo.metadb.model.web.PublishedMetadbRequest;
+import org.mskcc.cmo.metadb.model.web.RequestSummary;
 import org.mskcc.cmo.metadb.service.MetadbRequestService;
 import org.mskcc.cmo.metadb.service.exception.MetadbWebServiceException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -137,7 +138,7 @@ public class RequestController {
             "JSON with 'startDate' (required) and 'endDate' (optional) to query for.", required = true)
             @RequestBody DateRange dateRange,  ReturnTypeDetails returnType) throws Exception {
         // get request summary for given date range
-        List<List<String>> requestSummaryList;
+        List<RequestSummary> requestSummaryList;
         try {
             requestSummaryList = requestService.getRequestsByDate(
                     dateRange.getStartDate(), dateRange.getEndDate());
@@ -152,8 +153,8 @@ public class RequestController {
         // make list of request ids if specified
         if (returnType.equals(ReturnTypeDetails.REQUEST_ID_LIST)) {
             List<String> requestIds = new ArrayList<>();
-            for (List<String> request: requestSummaryList) {
-                requestIds.add(request.get(1));
+            for (RequestSummary request: requestSummaryList) {
+                requestIds.add(request.getRequestId());
             }
             return sendResponse(requestIds);
         }


### PR DESCRIPTION
RequestSummary endpoint now returns descriptive list of RequestSummary objects
when returning detailed results Instead of a List<List<String>>

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>