### PR TITLE
Sample updates ptswap

### DIFF
--- a/model/src/main/java/org/mskcc/smile/model/SmilePatient.java
+++ b/model/src/main/java/org/mskcc/smile/model/SmilePatient.java
@@ -30,6 +30,11 @@ public class SmilePatient implements Serializable {
 
     public SmilePatient() {}
 
+    public SmilePatient(String aliasValue, String aliasNamespace) {
+        this.patientAliases = new ArrayList<>();
+        patientAliases.add(new PatientAlias(aliasValue, aliasNamespace));
+    }
+
     public UUID getSmilePatientId() {
         return smilePatientId;
     }

--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileSampleRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileSampleRepository.java
@@ -105,4 +105,10 @@ public interface SmileSampleRepository extends Neo4jRepository<SmileSample, UUID
             + "OR sm.cmoSampleName = $inputId "
             + "RETURN s;")
     SmileSample findSampleByInputId(@Param("inputId") String inputId);
+
+    @Query("MATCH (s: Sample {smileSampleId: $smileSampleId}) "
+            + "MATCH (s)<-[r:HAS_SAMPLE]-(p: Patient {smilePatientId: $smilePatientId}) "
+            + "DELETE r")
+    void removeSamplePatientRelationship(@Param("smileSampleId") UUID smileSampleId,
+            @Param("smilePatientId") UUID smilePatientId);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,10 @@
     <testcontainers.version>1.16.0</testcontainers.version>
     <!-- smile messaging and shared entities dependency versions -->
     <smile_messaging_java.group>com.github.mskcc</smile_messaging_java.group>
-    <smile_messaging_java.version>1.3.3.RELEASE</smile_messaging_java.version>
+    <smile_messaging_java.version>1.3.4.RELEASE</smile_messaging_java.version>
     <!-- smile commons centralized config properties -->
     <smile_commons.group>com.github.mskcc</smile_commons.group>
-    <smile_commons.version>1.3.3.RELEASE</smile_commons.version>
+    <smile_commons.version>1.3.4.RELEASE</smile_commons.version>
     <!-- smile expected schema version -->
     <smile.schema_version>v2.2</smile.schema_version>
   </properties>

--- a/service/src/main/java/org/mskcc/smile/service/SmileSampleService.java
+++ b/service/src/main/java/org/mskcc/smile/service/SmileSampleService.java
@@ -10,7 +10,7 @@ import org.mskcc.smile.model.web.SmileSampleIdMapping;
 
 public interface SmileSampleService {
     SmileSample saveSmileSample(SmileSample smileSample) throws Exception;
-    SmileSample fetchAndLoadSampleDetails(SmileSample smileSample) throws Exception;
+    SmileSample fetchAndLoadPatientDetails(SmileSample smileSample) throws Exception;
     Boolean updateSampleMetadata(SampleMetadata sampleMetadata) throws Exception;
     List<SmileSample> getMatchedNormalsBySample(SmileSample smileSample)
             throws Exception;
@@ -19,7 +19,8 @@ public interface SmileSampleService {
     SmileSample getResearchSampleByRequestAndIgoId(String requestId, String igoId) throws Exception;
     List<SmileSample> getResearchSamplesByRequestId(String requestId) throws Exception;
     List<SampleMetadata> getResearchSampleMetadataHistoryByIgoId(String igoId) throws Exception;
-    Boolean sampleHasMetadataUpdates(SampleMetadata existingSampleMetadata, SampleMetadata sampleMetadata)
+    Boolean sampleHasMetadataUpdates(SampleMetadata existingSampleMetadata,
+            SampleMetadata sampleMetadata, Boolean isResearchSample)
             throws Exception;
     PublishedSmileSample getPublishedSmileSample(UUID smileSampleId) throws Exception;
     List<PublishedSmileSample> getPublishedSmileSamplesByCmoPatientId(String cmoPatientId)

--- a/service/src/main/java/org/mskcc/smile/service/impl/ClinicalMessageHandlingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/ClinicalMessageHandlingServiceImpl.java
@@ -126,7 +126,7 @@ public class ClinicalMessageHandlingServiceImpl implements ClinicalMessageHandli
                                     mapper.writeValueAsString(smileSample));
                         } else if (sampleService.sampleHasMetadataUpdates(
                                 existingSample.getLatestSampleMetadata(),
-                                smileSample.getLatestSampleMetadata())) {
+                                smileSample.getLatestSampleMetadata(), Boolean.FALSE)) {
                             LOG.info("Found updates for sample - persisting to database: "
                                     + smileSample.getPrimarySampleAlias());
                             existingSample.updateSampleMetadata(smileSample.getLatestSampleMetadata());
@@ -180,7 +180,7 @@ public class ClinicalMessageHandlingServiceImpl implements ClinicalMessageHandli
                                     mapper.writeValueAsString(smileSample));
                         } else if (sampleService.sampleHasMetadataUpdates(
                                 existingSample.getLatestSampleMetadata(),
-                                smileSample.getLatestSampleMetadata())) {
+                                smileSample.getLatestSampleMetadata(), Boolean.FALSE)) {
                             LOG.info("Found updates for sample - persisting to database: "
                                     + smileSample.getPrimarySampleAlias());
                             existingSample.updateSampleMetadata(smileSample.getLatestSampleMetadata());
@@ -244,6 +244,11 @@ public class ClinicalMessageHandlingServiceImpl implements ClinicalMessageHandli
                             DmpSampleMetadata.class);
                     String cmoPatientId = crdbMappingService.getCmoPatientIdbyDmpId(
                             dmpSample.getDmpPatientId());
+                    if (cmoPatientId == null) {
+                        LOG.error("Could not resolve cmoPatientId from dmpId: "
+                                + dmpSample.getDmpPatientId());
+                        return;
+                    }
                     SmileSample sample = SampleDataFactory.buildNewClinicalSampleFromMetadata(
                             cmoPatientId, dmpSample);
                     clinicalMessageHandlingService.newClinicalSampleHandler(sample);
@@ -268,6 +273,11 @@ public class ClinicalMessageHandlingServiceImpl implements ClinicalMessageHandli
                             DmpSampleMetadata.class);
                     String cmoPatientId = crdbMappingService.getCmoPatientIdbyDmpId(
                             dmpSample.getDmpPatientId());
+                    if (cmoPatientId == null) {
+                        LOG.error("Could not resolve cmoPatientId from dmpId: "
+                                + dmpSample.getDmpPatientId());
+                        return;
+                    }
                     SmileSample sample = SampleDataFactory.buildNewClinicalSampleFromMetadata(
                             cmoPatientId, dmpSample);
                     clinicalMessageHandlingService.clinicalSampleUpdateHandler(sample);

--- a/service/src/main/java/org/mskcc/smile/service/impl/RequestServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/RequestServiceImpl.java
@@ -206,27 +206,15 @@ public class RequestServiceImpl implements SmileRequestService {
 
     @Override
     public Boolean requestHasUpdates(SmileRequest existingRequest, SmileRequest request) throws Exception {
-        try {
-            jsonComparator.isConsistent(mapper.writeValueAsString(existingRequest),
-                mapper.writeValueAsString(request));
-        } catch (AssertionError e) {
-            LOG.warn("Found discrepancies between JSONs:\n" + e.getLocalizedMessage());
-            return Boolean.TRUE;
-        }
-        return Boolean.FALSE;
+        return !(jsonComparator.isConsistent(mapper.writeValueAsString(existingRequest),
+                mapper.writeValueAsString(request)));
     }
 
     @Override
     public Boolean requestHasMetadataUpdates(RequestMetadata existingRequestMetadata,
             RequestMetadata requestMetadata) throws Exception {
-        try {
-            jsonComparator.isConsistent(existingRequestMetadata.getRequestMetadataJson(),
-                    requestMetadata.getRequestMetadataJson());
-        } catch (AssertionError e) {
-            LOG.warn("Found discrepancies between JSONs:\n" + e.getLocalizedMessage());
-            return Boolean.TRUE;
-        }
-        return Boolean.FALSE;
+        return !(jsonComparator.isConsistent(existingRequestMetadata.getRequestMetadataJson(),
+                requestMetadata.getRequestMetadataJson()));
     }
 
     @Override
@@ -240,14 +228,10 @@ public class RequestServiceImpl implements SmileRequestService {
             if (existingSample == null) {
                 continue;
             }
-            // compare sample metadata from current request and the saved request
-            String latestMetadata = mapper.writeValueAsString(existingSample.getLatestSampleMetadata());
-            String currentMetadata = mapper.writeValueAsString(sample.getLatestSampleMetadata());
-
-            try {
-                jsonComparator.isConsistent(latestMetadata, currentMetadata);
-            } catch (AssertionError e) {
-                LOG.warn("Found discrepancies between JSONs:\n" + e.getLocalizedMessage());
+            Boolean sampleHasUpdates = 
+                    sampleService.sampleHasMetadataUpdates(existingSample.getLatestSampleMetadata(),
+                    sample.getLatestSampleMetadata(), Boolean.TRUE);
+            if (sampleHasUpdates) {
                 existingSample.updateSampleMetadata(sample.getLatestSampleMetadata());
                 updatedSamples.add(existingSample);
             }

--- a/service/src/main/java/org/mskcc/smile/service/impl/ResearchMessageHandlingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/ResearchMessageHandlingServiceImpl.java
@@ -53,6 +53,9 @@ public class ResearchMessageHandlingServiceImpl implements ResearchMessageHandli
     @Value("${smile.cmo_sample_update_topic}")
     private String CMO_SAMPLE_UPDATE_TOPIC;
 
+    @Value("${request_reply.cmo_label_generator_topic}")
+    private String CMO_LABEL_GENERATOR_REQREPLY_TOPIC;
+
     @Value("${num.new_request_handler_threads}")
     private int NUM_NEW_REQUEST_HANDLERS;
 
@@ -123,10 +126,10 @@ public class ResearchMessageHandlingServiceImpl implements ResearchMessageHandli
                             requestService.saveRequest(request);
                         } else {
                             // request-service and sample-service methods will check for updates and persist
-                            // them if applicable
+                            // them if applicable (including patient swapping)
                             requestService.updateRequestMetadata(request.getLatestRequestMetadata());
                             for (SmileSample sample : request.getSmileSampleList()) {
-                                sampleService.updateSampleMetadata(sample.getLatestSampleMetadata());
+                                sampleService.saveSmileSample(sample);
                             }
                         }
                         // publish updated/saved request to consistency checker or promoted request topic

--- a/service/src/main/java/org/mskcc/smile/service/util/SampleDataFactory.java
+++ b/service/src/main/java/org/mskcc/smile/service/util/SampleDataFactory.java
@@ -47,7 +47,9 @@ public class SampleDataFactory {
     public static SmileSample buildNewResearchSampleFromMetadata(String requestId,
             SampleMetadata sampleMetadata) {
         sampleMetadata.setIgoRequestId(requestId);
-        sampleMetadata.setImportDate(LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
+        if (sampleMetadata.getImportDate() == null) {
+            sampleMetadata.setImportDate(LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
+        }
 
         SmileSample sample = new SmileSample();
         sample.addSampleMetadata(sampleMetadata);


### PR DESCRIPTION
# Handle sample metadata updates with patient swap

Briefly describe changes proposed in this pull request:
- Handle scenario where a sample metadata update includes a patient swap.
  - sample-to-patient relationship is updated to point to the patient coming through with the latest sample metadata and former sample-to-patient relationship is removed to make sure sample only links to a single patient node
- Added unit tests for this scenario 

---
## Troubleshooting

Fix # bug fix for samples where metadata updates also includes a patient swap

**Expected behavior**
sample can have a patient swap during a metadata update


**Actual behavior**
sample was not swapping to the new patient after a metadata update, causing an error when attempting to fetch a request by a request id and/or sample by a cmo patient id

**Logs, error output, or stacktrace**
null pointer exception for any request with a sample that was not swapped to the new patient properly

**Steps to reproduce the behavior**
Import sample updates that includes an update to the patient cmo id

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Data checks:**
Updates were made to the mocked incoming request data and/or mocked published request data: `N/A`
```
- [ ] [smile-server test data](https://github.com/mskcc/smile-server/tree/master/service/src/test/resources/data)
- [ ] [smile-commons test data](https://github.com/mskcc/smile-commons/tree/master/src/test/resources/data)
- [ ] [smile-label-generator test data](https://github.com/mskcc/smile-label-generator/tree/master/src/test/resources/data)
- [ ] [smile-request-filter test data](https://github.com/mskcc/smile-request-filter/tree/master/src/test/resources/data)
```
**Code checks:**
- [x] Endpoints were tested to ensure their integrity.
- [x] Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.
- [x] Unit tests were updated in relation to updates to the mocked test data.

### II. Neo4j models and database schema checklist: `N/A`
```
- [ ] Neo4j persistence models were changed.
- [ ] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]
```
### III. Message handlers checklist:
- [n/a] ~~Changes in this PR affect the workflow of incoming messages.~~
- [x] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [x] Unit tests were added to ensure messages are handled as expected.

If no unit tests were updated or added, then please explain why: [insert details here]

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, **local docker**, dev server, production]
- Neo4j [local, **local docker**, dev server, production]
- SMILE Server [local, **local docker**, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, **smile publisher tool**, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### IV. Configuration and/or permissions checklist: `N/A`
```
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.
```
---
### Screenshots

**Before any updates**
- 2 patient nodes only
![image](https://user-images.githubusercontent.com/15623749/171259179-3ba8973d-63f1-4656-9f56-03e6aef30bf3.png)


**Confirmation of patient swap update:**
- 3 patient nodes instead of 2
- confirmation that the sample has a new metadata node (totaling 2 metadata nodes now)

![image](https://user-images.githubusercontent.com/15623749/171259304-6c2f3af3-4f77-4c94-9259-a77bc6f9d1d5.png)

**Swapping the sample back to the original patient.**
- There is still one extra patient that we can leave alone since it's possible that future samples coming in may link to this patient
- confirmation that the sample has yet another metadata node linked to it (totaling 3 metadata nodes now)
![image](https://user-images.githubusercontent.com/15623749/171259571-b92f9f8e-df8e-486e-8152-27164e9e43bb.png)

REST service:

Confirmed that fetching by a request id works (no longer seeing a NPE get thrown in the sample controller)
![image](https://user-images.githubusercontent.com/15623749/171262574-ecb23ccd-6956-426b-9d51-75a3824a8a1b.png)


Fetching samples by a cmo patient id (returns 2 for this cmo id)
![image](https://user-images.githubusercontent.com/15623749/171261909-ba99e8b8-98c3-44ac-89d5-2f4b2e59bd92.png)


Fetching samples by a cmo patient id after swap (fetching by the swapped patient id returns 1 sample)
![image](https://user-images.githubusercontent.com/15623749/171262030-9dbf2f01-7c87-41c2-9b77-ed9dd91f5172.png)

Fetching samples by the original cmo patient id also returns 1 sample that did not get the swap (expected behavior)
![image](https://user-images.githubusercontent.com/15623749/171262186-9cdf1ade-6ef2-4e7d-b581-11e2530da5a0.png)




---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
