### PR TITLE
Sample status bug fix

### DIFF
--- a/service/src/main/java/org/mskcc/smile/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/SampleServiceImpl.java
@@ -219,7 +219,8 @@ public class SampleServiceImpl implements SmileSampleService {
             }
             LOG.info("Persisting new sample to db: " + sampleMetadata.getPrimaryId());
             SmileSample sample = SampleDataFactory.buildNewResearchSampleFromMetadata(
-                    sampleMetadata.getIgoRequestId(), sampleMetadata, request.getIsCmoRequest());
+                    sampleMetadata.getIgoRequestId(), sampleMetadata,
+                    request.getIsCmoRequest(), sampleMetadata.getStatus());
             saveSmileSample(sample);
             createSampleRequestRelationship(sample.getSmileSampleId(), request.getSmileRequestId());
             return Boolean.TRUE;

--- a/service/src/main/java/org/mskcc/smile/service/util/SampleDataFactory.java
+++ b/service/src/main/java/org/mskcc/smile/service/util/SampleDataFactory.java
@@ -46,10 +46,11 @@ public class SampleDataFactory {
      * @param requestId
      * @param sampleMetadata
      * @param isCmoRequest
+     * @param sampleStatus
      * @return SmileSample
      */
     public static SmileSample buildNewResearchSampleFromMetadata(String requestId,
-            SampleMetadata sampleMetadata, Boolean isCmoRequest) {
+            SampleMetadata sampleMetadata, Boolean isCmoRequest, Status sampleStatus) {
         sampleMetadata.setIgoRequestId(requestId);
         if (sampleMetadata.getImportDate() == null) {
             sampleMetadata.setImportDate(LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
@@ -58,6 +59,7 @@ public class SampleDataFactory {
         if (isCmoRequest != null) {
             sampleMetadata.addAdditionalProperty("isCmoSample", Boolean.TRUE.toString());
         }
+        sampleMetadata.setStatus(sampleStatus);
 
         SmileSample sample = new SmileSample();
         sample.addSampleMetadata(sampleMetadata);
@@ -80,13 +82,15 @@ public class SampleDataFactory {
      * @param requestId
      * @param igoSampleManifest
      * @param isCmoRequest
+     * @param sampleStatus
      * @return SmileSample
      * @throws JsonProcessingException
      */
     public static SmileSample buildNewResearchSampleFromMetadata(String requestId,
-            IgoSampleManifest igoSampleManifest, Boolean isCmoRequest) throws JsonProcessingException {
+            IgoSampleManifest igoSampleManifest, Boolean isCmoRequest, Status sampleStatus)
+            throws JsonProcessingException {
         SampleMetadata sampleMetadata = new SampleMetadata(igoSampleManifest);
-        return buildNewResearchSampleFromMetadata(requestId, sampleMetadata, null);
+        return buildNewResearchSampleFromMetadata(requestId, sampleMetadata, null, sampleStatus);
     }
 
     /**

--- a/service/src/test/java/org/mskcc/smile/service/CorrectCmoPatientIdHandlerTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/CorrectCmoPatientIdHandlerTest.java
@@ -61,7 +61,9 @@ public class CorrectCmoPatientIdHandlerTest {
 
     /**
      * Persists the Mock Request data to the test database.
-     * @throws Exception
+     * @param requestRepository
+     * @param sampleRepository
+     * @param patientRepository
      */
     @Autowired
     public CorrectCmoPatientIdHandlerTest(SmileRequestRepository requestRepository,

--- a/service/src/test/resources/data/incoming_requests/mocked_request1_all_samples_missing_fastqs.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request1_all_samples_missing_fastqs.json
@@ -65,6 +65,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "PDX"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -105,6 +109,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "Blood"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -156,6 +164,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "PDX"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -208,6 +220,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "Blood"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request1_complete_tumor_normal.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request1_complete_tumor_normal.json
@@ -68,6 +68,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -123,6 +127,10 @@
         "sampleType": "Whole Blood",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -178,6 +186,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -233,6 +245,10 @@
         "sampleType": "Whole Blood",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request1_complete_tumor_normal_updated_libraries.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request1_complete_tumor_normal_updated_libraries.json
@@ -68,6 +68,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -123,6 +127,10 @@
         "sampleType": "Whole Blood",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -178,6 +186,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -233,6 +245,10 @@
         "sampleType": "Whole Blood",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request1_sample_missing_fastqs.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request1_sample_missing_fastqs.json
@@ -68,6 +68,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "PDX"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -123,6 +127,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "Blood"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -174,6 +182,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "PDX"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -226,6 +238,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "Blood"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request1_updated_complete_tumor_normal.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request1_updated_complete_tumor_normal.json
@@ -68,6 +68,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -123,6 +127,10 @@
         "sampleType": "Whole Blood",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -178,6 +186,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -233,6 +245,10 @@
         "sampleType": "Whole Blood",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request1a_sample_type_abbreviation.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request1a_sample_type_abbreviation.json
@@ -68,6 +68,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "PDX"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -123,6 +127,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "XenograftDerivedCellLine"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -178,6 +186,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "Exosome"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -233,6 +245,10 @@
         "sampleType": "Whole Blood",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request1b_nucleic_acid_abbreviation.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request1b_nucleic_acid_abbreviation.json
@@ -68,6 +68,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "PDX"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -123,6 +127,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "Blood"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -178,6 +186,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "PDX"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -233,6 +245,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "Blood"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request1c_missing_all_samples.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request1c_missing_all_samples.json
@@ -68,6 +68,10 @@
         "recipe": null,
         "normalizedPatientId": "wrongValue",
         "sampleType": "wrongValue"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -123,6 +127,10 @@
         "recipe": null,
         "normalizedPatientId": "wrongValue",
         "sampleType": "wrongValue"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -178,6 +186,10 @@
         "recipe": "",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "wrongValue"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -233,6 +245,10 @@
         "sampleType": null,
         "normalizedPatientId": "wrongValue",
         "recipe": ""
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request1d_missing_few_samples.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request1d_missing_few_samples.json
@@ -68,6 +68,10 @@
         "recipe": "",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": ""
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -123,6 +127,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "",
         "sampleType": null
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -178,6 +186,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "PDX"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -233,6 +245,10 @@
         "recipe": "GENESET101_BAITS",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "Blood"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request1e_null_string_baitset.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request1e_null_string_baitset.json
@@ -68,6 +68,10 @@
         "recipe": "null",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "PDX"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -123,6 +127,10 @@
         "recipe": "null",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "Blood"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -178,6 +186,10 @@
         "recipe": "null",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "PDX"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -233,6 +245,10 @@
         "recipe": "null",
         "normalizedPatientId": "testingNormalizedPatientIdvalue",
         "sampleType": "Blood"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request2a_one_empty_sample_metadata.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request2a_one_empty_sample_metadata.json
@@ -66,6 +66,10 @@
         "recipe": "",
         "normalizedPatientId": "",
         "sampleType": ""
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request2a_one_normal.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request2a_one_normal.json
@@ -77,6 +77,10 @@
         "sampleType": "Buffy Coat",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request2b_missing_one_normal.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request2b_missing_one_normal.json
@@ -80,6 +80,10 @@
         "sampleType": "Buffy Coat",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -147,6 +151,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -214,6 +222,10 @@
         "sampleType": "",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -248,6 +260,10 @@
         "sampleType": "Buffy Coat",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -315,6 +331,10 @@
         "sampleType": "Buffy Coat",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -382,6 +402,10 @@
         "sampleType": "Buffy Coat",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -449,6 +473,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -516,6 +544,10 @@
         "sampleType": "Buffy Coat",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -583,6 +615,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -650,6 +686,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -717,6 +757,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -784,6 +828,10 @@
         "sampleType": "Buffy Coat",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -851,6 +899,10 @@
         "sampleType": "Buffy Coat",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -918,6 +970,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -985,6 +1041,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -1052,6 +1112,10 @@
         "sampleType": "Buffy Coat",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -1119,6 +1183,10 @@
         "sampleType": "Buffy Coat",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -1186,6 +1254,10 @@
         "sampleType": "Buffy Coat",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -1253,6 +1325,10 @@
         "sampleType": "Buffy Coat",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -1320,6 +1396,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -1387,6 +1467,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request3_pooled_normals.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request3_pooled_normals.json
@@ -75,6 +75,10 @@
         "sampleType": "Sorted Cells",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -137,6 +141,10 @@
         "sampleType": "Sorted Cells",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -199,6 +207,10 @@
         "sampleType": "Sorted Cells",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -261,6 +273,10 @@
         "sampleType": "Sorted Cells",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request4_null_or_empty_values.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request4_null_or_empty_values.json
@@ -68,6 +68,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -123,6 +127,10 @@
         "sampleType": "Whole Blood",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -178,6 +186,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -233,6 +245,10 @@
         "sampleType": "Whole Blood",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request5_pt_multi_samples.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request5_pt_multi_samples.json
@@ -69,6 +69,10 @@
         "sampleType": "Plasma",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "null"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -123,6 +127,10 @@
         "sampleType": "Plasma",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "null"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -177,6 +185,10 @@
         "sampleType": "Plasma",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "null"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -231,6 +243,10 @@
         "sampleType": "Plasma",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "null"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -285,6 +301,10 @@
         "sampleType": "Plasma",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "null"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -339,6 +359,10 @@
         "sampleType": "Plasma",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "null"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request6_cmopt_after_swap.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request6_cmopt_after_swap.json
@@ -68,6 +68,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -123,6 +127,10 @@
         "sampleType": "Whole Blood",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -178,6 +186,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -233,6 +245,10 @@
         "sampleType": "Whole Blood",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],

--- a/service/src/test/resources/data/incoming_requests/mocked_request6_cmopt_swap.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request6_cmopt_swap.json
@@ -68,6 +68,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -123,6 +127,10 @@
         "sampleType": "Whole Blood",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -178,6 +186,10 @@
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     },
     {
@@ -233,6 +245,10 @@
         "sampleType": "Whole Blood",
         "normalizedPatientId": "MRN_REDACTED",
         "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
       }
     }
   ],


### PR DESCRIPTION
sample `status` was not getting extracted properly from the new igo requests or when building sample objects from IGO sample manifest JSONs