### PR TITLE
Fix request not found return handling

### DIFF
--- a/service/src/main/java/org/mskcc/smile/service/impl/RequestServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/RequestServiceImpl.java
@@ -157,6 +157,9 @@ public class RequestServiceImpl implements SmileRequestService {
     @Override
     public PublishedSmileRequest getPublishedSmileRequestById(String requestId) throws Exception {
         SmileRequest request = getSmileRequestById(requestId);
+        if (request == null) {
+            return null;
+        }
 
         // for each smile sample get the latest version of its sample metadata
         List<PublishedSmileSample> samples = new ArrayList<>();


### PR DESCRIPTION
# Fix requests not found return handling

Briefly describe changes proposed in this pull request:
- Cleans up the logs and reports requests not found as a 404 error

The 404 error handling was already in place but the method used for fetching the request by an ID was returning null if request wasn't found. 
