### PR TITLE
Corresponding changes to mocked data for request filter catching missing CMO patient IDs in sample records 

### DIFF
--- a/service/src/main/java/org/mskcc/smile/service/util/RequestDataFactory.java
+++ b/service/src/main/java/org/mskcc/smile/service/util/RequestDataFactory.java
@@ -55,7 +55,6 @@ public class RequestDataFactory {
     private static List<SmileSample> extractSmileSamplesFromIgoResponse(Object message)
             throws JsonProcessingException {
         Map<String, Object> map = mapper.readValue(message.toString(), Map.class);
-        /// SAMPLE STATUS NOT GETTING SET HERE
         List<Object> sampleManifests =
                 Arrays.asList(mapper.convertValue(map.get("samples"),
                         Object[].class));

--- a/service/src/test/java/org/mskcc/smile/service/RequestDataFactoryUtilTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/RequestDataFactoryUtilTest.java
@@ -26,7 +26,7 @@ public class RequestDataFactoryUtilTest {
     @Test
     public void testResearchSamplesAndRequestDataLoading() throws Exception {
         for (Map.Entry<String, MockJsonTestData> entry : mockDataUtils.mockedRequestJsonDataMap.entrySet()) {
-            if (!entry.getKey().startsWith("mockIncoming")) {
+            if (!entry.getKey().startsWith("mockIncoming") && !entry.getKey().startsWith("mockValidated")) {
                 continue;
             }
             String jsonString = entry.getValue().getJsonString();

--- a/service/src/test/resources/data/incoming_requests/mocked_request7_samples_missing_pids.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request7_samples_missing_pids.json
@@ -1,0 +1,252 @@
+{
+  "requestId": "98765_X",
+  "requestName": "RNASeq-TruSeqPolyA",
+  "recipe": "RNASeq_PolyA",
+  "projectManagerName": "",
+  "piEmail": "",
+  "labHeadName": "Dana Scully",
+  "labHeadEmail": "email@address.com",
+  "investigatorName": "Fox Mulder",
+  "investigatorEmail": "email@address.com",
+  "dataAnalystName": "",
+  "dataAnalystEmail": "",
+  "otherContactEmails": "email@address.com",
+  "dataAccessEmails": "",
+  "qcAccessEmails": "",
+  "strand": "stranded-reverse",
+  "libraryType": "RNASeq-TruSeqPolyA",
+  "isCmoRequest": true,
+  "bicAnalysis": false,
+  "samples": [
+    {
+      "igoId": "98765_X_4",
+      "cmoSampleName": "",
+      "sampleName": "KG324li_base",
+      "cmoSampleClass": "Metastasis",
+      "cmoPatientId": "",
+      "investigatorSampleId": "KG324li_base",
+      "oncoTreeCode": "",
+      "tumorOrNormal": "Tumor",
+      "tissueLocation": "",
+      "specimenType": "CellLine",
+      "sampleOrigin": "Cell Pellet",
+      "preservation": "Frozen",
+      "collectionYear": "",
+      "sex": "",
+      "species": "Human",
+      "tubeId": "KG324li_base",
+      "cfDNA2dBarcode": null,
+      "baitSet": "null",
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": null,
+          "barcodeIndex": null,
+          "libraryIgoId": null,
+          "libraryVolume": null,
+          "libraryConcentrationNgul": null,
+          "dnaInputNg": null,
+          "captureConcentrationNm": null,
+          "captureInputNg": null,
+          "captureName": null,
+          "runs": [
+            {
+              "runMode": null,
+              "runId": "RUNID_0456",
+              "flowCellId": "CELLID456",
+              "readLength": null,
+              "runDate": "2023-06-23",
+              "flowCellLanes": [],
+              "fastqs": [
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG324li_base_IGO_98765_X_4/KG324li_base_IGO_98765_X_4_S14_L001_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG324li_base_IGO_98765_X_4/KG324li_base_IGO_98765_X_4_S14_L001_R2_001.fastq.gz",
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG324li_base_IGO_98765_X_4/KG324li_base_IGO_98765_X_4_S14_L002_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG324li_base_IGO_98765_X_4/KG324li_base_IGO_98765_X_4_S14_L002_R2_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "cmoSampleIdFields": {
+        "naToExtract": "RNA",
+        "normalizedPatientId": "",
+        "sampleType": "RNA",
+        "recipe": "RNASeq_PolyA"
+      },
+      "igoComplete": true
+    },
+    {
+      "igoId": "98765_X_3",
+      "cmoSampleName": "",
+      "sampleName": "KG090li_base",
+      "cmoSampleClass": "Metastasis",
+      "cmoPatientId": "",
+      "investigatorSampleId": "KG090li_base",
+      "oncoTreeCode": "",
+      "tumorOrNormal": "Tumor",
+      "tissueLocation": "",
+      "specimenType": "CellLine",
+      "sampleOrigin": "Cell Pellet",
+      "preservation": "Frozen",
+      "collectionYear": "",
+      "sex": "",
+      "species": "Human",
+      "tubeId": "KG090li_base",
+      "cfDNA2dBarcode": null,
+      "baitSet": "null",
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": null,
+          "barcodeIndex": null,
+          "libraryIgoId": null,
+          "libraryVolume": null,
+          "libraryConcentrationNgul": null,
+          "dnaInputNg": null,
+          "captureConcentrationNm": null,
+          "captureInputNg": null,
+          "captureName": null,
+          "runs": [
+            {
+              "runMode": null,
+              "runId": "RUNID_0456",
+              "flowCellId": "CELLID456",
+              "readLength": null,
+              "runDate": "2023-06-23",
+              "flowCellLanes": [],
+              "fastqs": [
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG090li_base_IGO_98765_X_3/KG090li_base_IGO_98765_X_3_S13_L001_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG090li_base_IGO_98765_X_3/KG090li_base_IGO_98765_X_3_S13_L001_R2_001.fastq.gz",
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG090li_base_IGO_98765_X_3/KG090li_base_IGO_98765_X_3_S13_L002_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG090li_base_IGO_98765_X_3/KG090li_base_IGO_98765_X_3_S13_L002_R2_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "cmoSampleIdFields": {
+        "naToExtract": "RNA",
+        "normalizedPatientId": "",
+        "sampleType": "RNA",
+        "recipe": "RNASeq_PolyA"
+      },
+      "igoComplete": true
+    },
+    {
+      "igoId": "98765_X_2",
+      "cmoSampleName": "",
+      "sampleName": "KG944N",
+      "cmoSampleClass": "Normal",
+      "cmoPatientId": "",
+      "investigatorSampleId": "KG944N",
+      "oncoTreeCode": null,
+      "tumorOrNormal": "Normal",
+      "tissueLocation": "",
+      "specimenType": "CellLine",
+      "sampleOrigin": "Cell Pellet",
+      "preservation": "Frozen",
+      "collectionYear": "",
+      "sex": "",
+      "species": "Human",
+      "tubeId": "KG944N",
+      "cfDNA2dBarcode": null,
+      "baitSet": "null",
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": null,
+          "barcodeIndex": null,
+          "libraryIgoId": null,
+          "libraryVolume": null,
+          "libraryConcentrationNgul": null,
+          "dnaInputNg": null,
+          "captureConcentrationNm": null,
+          "captureInputNg": null,
+          "captureName": null,
+          "runs": [
+            {
+              "runMode": null,
+              "runId": "RUNID_0456",
+              "flowCellId": "CELLID456",
+              "readLength": null,
+              "runDate": "2023-06-23",
+              "flowCellLanes": [],
+              "fastqs": [
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG944N_IGO_98765_X_2/KG944N_IGO_98765_X_2_S12_L001_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG944N_IGO_98765_X_2/KG944N_IGO_98765_X_2_S12_L001_R2_001.fastq.gz",
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG944N_IGO_98765_X_2/KG944N_IGO_98765_X_2_S12_L002_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG944N_IGO_98765_X_2/KG944N_IGO_98765_X_2_S12_L002_R2_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "cmoSampleIdFields": {
+        "naToExtract": "RNA",
+        "normalizedPatientId": "",
+        "sampleType": "RNA",
+        "recipe": "RNASeq_PolyA"
+      },
+      "igoComplete": true
+    },
+    {
+      "igoId": "98765_X_1",
+      "cmoSampleName": "",
+      "sampleName": "KG882N",
+      "cmoSampleClass": "Normal",
+      "cmoPatientId": "",
+      "investigatorSampleId": "KG882N",
+      "oncoTreeCode": null,
+      "tumorOrNormal": "Normal",
+      "tissueLocation": "",
+      "specimenType": "CellLine",
+      "sampleOrigin": "Cell Pellet",
+      "preservation": "Frozen",
+      "collectionYear": "",
+      "sex": "",
+      "species": "Human",
+      "tubeId": "KG882N",
+      "cfDNA2dBarcode": null,
+      "baitSet": "null",
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": null,
+          "barcodeIndex": null,
+          "libraryIgoId": null,
+          "libraryVolume": null,
+          "libraryConcentrationNgul": null,
+          "dnaInputNg": null,
+          "captureConcentrationNm": null,
+          "captureInputNg": null,
+          "captureName": null,
+          "runs": [
+            {
+              "runMode": null,
+              "runId": "RUNID_0456",
+              "flowCellId": "CELLID456",
+              "readLength": null,
+              "runDate": "2023-06-23",
+              "flowCellLanes": [],
+              "fastqs": [
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG882N_IGO_98765_X_1/KG882N_IGO_98765_X_1_S11_L001_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG882N_IGO_98765_X_1/KG882N_IGO_98765_X_1_S11_L001_R2_001.fastq.gz",
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG882N_IGO_98765_X_1/KG882N_IGO_98765_X_1_S11_L002_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG882N_IGO_98765_X_1/KG882N_IGO_98765_X_1_S11_L002_R2_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "cmoSampleIdFields": {
+        "naToExtract": "RNA",
+        "normalizedPatientId": "",
+        "sampleType": "RNA",
+        "recipe": "RNASeq_PolyA"
+      },
+      "igoComplete": true
+    }
+  ],
+  "pooledNormals": null,
+  "projectId": "98765"
+}

--- a/service/src/test/resources/data/mocked_request_data_details.txt
+++ b/service/src/test/resources/data/mocked_request_data_details.txt
@@ -26,3 +26,5 @@ mockRequest1SamplesMissingFastQs	incoming_requests/mocked_request1_sample_missin
 mockRequest1AllSamplesMissingFastQs	incoming_requests/mocked_request1_all_samples_missing_fastqs.json	Mock requset json with all samples missing fastqs
 mockRequest1eNullStringBaitSet	incoming_requests/mocked_request1e_null_string_baitset.json	Mock requset json with "null" baitset values
 mockIncomingRequest1JsonDataWithLibraryUpdate	incoming_requests/mocked_request1_complete_tumor_normal_updated_libraries.json	Mock incoming request json with 2 tumor samples and 2 matching normals. Updated libraries for one sample.
+mockRequest7SamplesMissingPids	incoming_requests/mocked_request7_samples_missing_pids.json	Mock request where all samples are missing CMO patient IDs.
+mockValidatedRequest7SamplesMissingPids	other_mocked_data/mocked_validated_request7_samples_missing_pids.json	Request JSON after going through validation and sanity checks in request filter. Based on 'mockRequest7SamplesMissingPids'.

--- a/service/src/test/resources/data/other_mocked_data/mocked_validated_request7_samples_missing_pids.json
+++ b/service/src/test/resources/data/other_mocked_data/mocked_validated_request7_samples_missing_pids.json
@@ -1,0 +1,282 @@
+{
+  "requestId": "98765_X",
+  "requestName": "RNASeq-TruSeqPolyA",
+  "recipe": "RNASeq_PolyA",
+  "projectManagerName": "",
+  "piEmail": "",
+  "labHeadName": "Dana Scully",
+  "labHeadEmail": "email@address.com",
+  "investigatorName": "Fox Mulder",
+  "investigatorEmail": "email@address.com",
+  "dataAnalystName": "",
+  "dataAnalystEmail": "",
+  "otherContactEmails": "email@address.com",
+  "dataAccessEmails": "",
+  "qcAccessEmails": "",
+  "strand": "stranded-reverse",
+  "libraryType": "RNASeq-TruSeqPolyA",
+  "isCmoRequest": true,
+  "bicAnalysis": false,
+  "samples": [],
+  "pooledNormals": null,
+  "projectId": "98765",
+  "status": {
+    "validationReport": {
+      "samples": [
+        {
+          "igoId": "98765_X_4",
+          "cmoSampleName": "",
+          "sampleName": "KG324li_base",
+          "cmoSampleClass": "Metastasis",
+          "cmoPatientId": "",
+          "investigatorSampleId": "KG324li_base",
+          "oncoTreeCode": "",
+          "tumorOrNormal": "Tumor",
+          "tissueLocation": "",
+          "specimenType": "CellLine",
+          "sampleOrigin": "Cell Pellet",
+          "preservation": "Frozen",
+          "collectionYear": "",
+          "sex": "",
+          "species": "Human",
+          "tubeId": "KG324li_base",
+          "cfDNA2dBarcode": null,
+          "baitSet": "null",
+          "qcReports": [],
+          "libraries": [
+            {
+              "barcodeId": null,
+              "barcodeIndex": null,
+              "libraryIgoId": null,
+              "libraryVolume": null,
+              "libraryConcentrationNgul": null,
+              "dnaInputNg": null,
+              "captureConcentrationNm": null,
+              "captureInputNg": null,
+              "captureName": null,
+              "runs": [
+                {
+                  "runMode": null,
+                  "runId": "RUNID_0456",
+                  "flowCellId": "CELLID456",
+                  "readLength": null,
+                  "runDate": "2023-06-23",
+                  "flowCellLanes": [],
+                  "fastqs": [
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG324li_base_IGO_98765_X_4/KG324li_base_IGO_98765_X_4_S14_L001_R1_001.fastq.gz",
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG324li_base_IGO_98765_X_4/KG324li_base_IGO_98765_X_4_S14_L001_R2_001.fastq.gz",
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG324li_base_IGO_98765_X_4/KG324li_base_IGO_98765_X_4_S14_L002_R1_001.fastq.gz",
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG324li_base_IGO_98765_X_4/KG324li_base_IGO_98765_X_4_S14_L002_R2_001.fastq.gz"
+                  ]
+                }
+              ]
+            }
+          ],
+          "cmoSampleIdFields": {
+            "naToExtract": "RNA",
+            "normalizedPatientId": "",
+            "sampleType": "RNA",
+            "recipe": "RNASeq_PolyA"
+          },
+          "igoComplete": true,
+          "status": {
+            "validationReport": {
+              "cmoPatientId": "missing"
+            },
+            "validationStatus": false
+          }
+        },
+        {
+          "igoId": "98765_X_3",
+          "cmoSampleName": "",
+          "sampleName": "KG090li_base",
+          "cmoSampleClass": "Metastasis",
+          "cmoPatientId": "",
+          "investigatorSampleId": "KG090li_base",
+          "oncoTreeCode": "",
+          "tumorOrNormal": "Tumor",
+          "tissueLocation": "",
+          "specimenType": "CellLine",
+          "sampleOrigin": "Cell Pellet",
+          "preservation": "Frozen",
+          "collectionYear": "",
+          "sex": "",
+          "species": "Human",
+          "tubeId": "KG090li_base",
+          "cfDNA2dBarcode": null,
+          "baitSet": "null",
+          "qcReports": [],
+          "libraries": [
+            {
+              "barcodeId": null,
+              "barcodeIndex": null,
+              "libraryIgoId": null,
+              "libraryVolume": null,
+              "libraryConcentrationNgul": null,
+              "dnaInputNg": null,
+              "captureConcentrationNm": null,
+              "captureInputNg": null,
+              "captureName": null,
+              "runs": [
+                {
+                  "runMode": null,
+                  "runId": "RUNID_0456",
+                  "flowCellId": "CELLID456",
+                  "readLength": null,
+                  "runDate": "2023-06-23",
+                  "flowCellLanes": [],
+                  "fastqs": [
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG090li_base_IGO_98765_X_3/KG090li_base_IGO_98765_X_3_S13_L001_R1_001.fastq.gz",
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG090li_base_IGO_98765_X_3/KG090li_base_IGO_98765_X_3_S13_L001_R2_001.fastq.gz",
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG090li_base_IGO_98765_X_3/KG090li_base_IGO_98765_X_3_S13_L002_R1_001.fastq.gz",
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG090li_base_IGO_98765_X_3/KG090li_base_IGO_98765_X_3_S13_L002_R2_001.fastq.gz"
+                  ]
+                }
+              ]
+            }
+          ],
+          "cmoSampleIdFields": {
+            "naToExtract": "RNA",
+            "normalizedPatientId": "",
+            "sampleType": "RNA",
+            "recipe": "RNASeq_PolyA"
+          },
+          "igoComplete": true,
+          "status": {
+            "validationReport": {
+              "cmoPatientId": "missing"
+            },
+            "validationStatus": false
+          }
+        },
+        {
+          "igoId": "98765_X_2",
+          "cmoSampleName": "",
+          "sampleName": "KG944N",
+          "cmoSampleClass": "Normal",
+          "cmoPatientId": "",
+          "investigatorSampleId": "KG944N",
+          "oncoTreeCode": null,
+          "tumorOrNormal": "Normal",
+          "tissueLocation": "",
+          "specimenType": "CellLine",
+          "sampleOrigin": "Cell Pellet",
+          "preservation": "Frozen",
+          "collectionYear": "",
+          "sex": "",
+          "species": "Human",
+          "tubeId": "KG944N",
+          "cfDNA2dBarcode": null,
+          "baitSet": "null",
+          "qcReports": [],
+          "libraries": [
+            {
+              "barcodeId": null,
+              "barcodeIndex": null,
+              "libraryIgoId": null,
+              "libraryVolume": null,
+              "libraryConcentrationNgul": null,
+              "dnaInputNg": null,
+              "captureConcentrationNm": null,
+              "captureInputNg": null,
+              "captureName": null,
+              "runs": [
+                {
+                  "runMode": null,
+                  "runId": "RUNID_0456",
+                  "flowCellId": "CELLID456",
+                  "readLength": null,
+                  "runDate": "2023-06-23",
+                  "flowCellLanes": [],
+                  "fastqs": [
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG944N_IGO_98765_X_2/KG944N_IGO_98765_X_2_S12_L001_R1_001.fastq.gz",
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG944N_IGO_98765_X_2/KG944N_IGO_98765_X_2_S12_L001_R2_001.fastq.gz",
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG944N_IGO_98765_X_2/KG944N_IGO_98765_X_2_S12_L002_R1_001.fastq.gz",
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG944N_IGO_98765_X_2/KG944N_IGO_98765_X_2_S12_L002_R2_001.fastq.gz"
+                  ]
+                }
+              ]
+            }
+          ],
+          "cmoSampleIdFields": {
+            "naToExtract": "RNA",
+            "normalizedPatientId": "",
+            "sampleType": "RNA",
+            "recipe": "RNASeq_PolyA"
+          },
+          "igoComplete": true,
+          "status": {
+            "validationReport": {
+              "cmoPatientId": "missing"
+            },
+            "validationStatus": false
+          }
+        },
+        {
+          "igoId": "98765_X_1",
+          "cmoSampleName": "",
+          "sampleName": "KG882N",
+          "cmoSampleClass": "Normal",
+          "cmoPatientId": "",
+          "investigatorSampleId": "KG882N",
+          "oncoTreeCode": null,
+          "tumorOrNormal": "Normal",
+          "tissueLocation": "",
+          "specimenType": "CellLine",
+          "sampleOrigin": "Cell Pellet",
+          "preservation": "Frozen",
+          "collectionYear": "",
+          "sex": "",
+          "species": "Human",
+          "tubeId": "KG882N",
+          "cfDNA2dBarcode": null,
+          "baitSet": "null",
+          "qcReports": [],
+          "libraries": [
+            {
+              "barcodeId": null,
+              "barcodeIndex": null,
+              "libraryIgoId": null,
+              "libraryVolume": null,
+              "libraryConcentrationNgul": null,
+              "dnaInputNg": null,
+              "captureConcentrationNm": null,
+              "captureInputNg": null,
+              "captureName": null,
+              "runs": [
+                {
+                  "runMode": null,
+                  "runId": "RUNID_0456",
+                  "flowCellId": "CELLID456",
+                  "readLength": null,
+                  "runDate": "2023-06-23",
+                  "flowCellLanes": [],
+                  "fastqs": [
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG882N_IGO_98765_X_1/KG882N_IGO_98765_X_1_S11_L001_R1_001.fastq.gz",
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG882N_IGO_98765_X_1/KG882N_IGO_98765_X_1_S11_L001_R2_001.fastq.gz",
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG882N_IGO_98765_X_1/KG882N_IGO_98765_X_1_S11_L002_R1_001.fastq.gz",
+                    "/igo/delivery/FASTQ/RUNID_0456/Project_98765_X/Sample_KG882N_IGO_98765_X_1/KG882N_IGO_98765_X_1_S11_L002_R2_001.fastq.gz"
+                  ]
+                }
+              ]
+            }
+          ],
+          "cmoSampleIdFields": {
+            "naToExtract": "RNA",
+            "normalizedPatientId": "",
+            "sampleType": "RNA",
+            "recipe": "RNASeq_PolyA"
+          },
+          "igoComplete": true,
+          "status": {
+            "validationReport": {
+              "cmoPatientId": "missing"
+            },
+            "validationStatus": false
+          }
+        }
+      ]
+    },
+    "validationStatus": false
+  }
+}


### PR DESCRIPTION
# Changes to support request-filter catching missing CMO patient IDs

Corresponding changes for request-filter PR #54: https://github.com/mskcc/smile-request-filter/pull/54
