### PR TITLE
Patient DMP ID lookup

### DIFF
--- a/model/src/main/java/org/mskcc/smile/model/SmilePatient.java
+++ b/model/src/main/java/org/mskcc/smile/model/SmilePatient.java
@@ -122,6 +122,24 @@ public class SmilePatient implements Serializable {
         return Boolean.FALSE;
     }
 
+    /**
+     * Determines whether Patient has a patient alias matching the namespace provided.
+     * @param patientAliasNamespace
+     * @return Boolean
+     */
+    public Boolean hasPatientAlias(String patientAliasNamespace) {
+        if (patientAliases == null) {
+            patientAliases = new ArrayList<>();
+            return Boolean.FALSE;
+        }
+        for (PatientAlias alias : patientAliases) {
+            if (alias.getNamespace().equalsIgnoreCase(patientAliasNamespace)) {
+                return Boolean.TRUE;
+            }
+        }
+        return Boolean.FALSE;
+    }
+
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);

--- a/service/src/main/java/org/mskcc/smile/service/impl/CrdbMappingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/CrdbMappingServiceImpl.java
@@ -67,7 +67,9 @@ public class CrdbMappingServiceImpl implements CrdbMappingService {
     @Override
     public CrdbMappingModel getCrdbMappingModelByInputId(String inputId) throws Exception {
         //Add check for if the input query starts with "C-" then remove it (replace with empty string)
-        inputId.replace("C-", "");
+        if (inputId.startsWith("C-")) {
+            inputId.replace("C-", "");
+        }
         Callable<Object> task = new Callable<Object>() {
             @Override
             public Object call() {


### PR DESCRIPTION
# Patient DMP ID lookup

Briefly describe changes proposed in this pull request:

If an incoming sample's patient does not already have an alias belonging to namespace `dmpId` then the CRDB crosswalk table is queried by the patient CMO ID. 

These changes will allow patients that are imported during the research sample import process to have DMP IDs and help prevent the redundant patient nodes that get created when a clinical patient/sample is imported prior to a research sample belonging to the same patient.
