### PR TITLE
Rename BamComplete's property 'timestamp' to 'date'

### DIFF
--- a/model/src/main/java/org/mskcc/smile/model/tempo/BamComplete.java
+++ b/model/src/main/java/org/mskcc/smile/model/tempo/BamComplete.java
@@ -13,13 +13,13 @@ import org.neo4j.ogm.annotation.NodeEntity;
 public class BamComplete {
     @Id @GeneratedValue
     private Long id;
-    private String timestamp;
+    private String date;
     private String status;
 
     public BamComplete() {}
 
-    public BamComplete(String timestamp, String status) {
-        this.timestamp = timestamp;
+    public BamComplete(String date, String status) {
+        this.date = date;
         this.status = status;
     }
 
@@ -32,11 +32,11 @@ public class BamComplete {
     }
 
     public String getDate() {
-        return timestamp;
+        return date;
     }
 
     public void setDate(String date) {
-        this.timestamp = date;
+        this.date = date;
     }
 
     public String getStatus() {

--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/TempoRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/TempoRepository.java
@@ -28,12 +28,12 @@ public interface TempoRepository extends Neo4jRepository<Tempo, Long> {
     List<BamComplete> findBamCompleteEventsByTempoId(@Param("tempoId") Long tempoId);
 
     @Query("MATCH (t:Tempo) WHERE ID(t) = $tempoId MATCH (t)-[:HAS_EVENT]->(bc: BamComplete) "
-            + "RETURN bc ORDER BY bc.timestamp DESC LIMIT 1")
+            + "RETURN bc ORDER BY bc.date DESC LIMIT 1")
     BamComplete findLatestBamCompleteEventByTempoId(@Param("tempoId") Long tempoId);
 
     @Query("MATCH (s: Sample)-[:HAS_METADATA]->(sm: SampleMetadata {primaryId: $primaryId}) "
             + "MERGE (s)-[:HAS_TEMPO]->(t: Tempo) WITH s,t "
-            + "MERGE (t)-[:HAS_EVENT]->(bc: BamComplete {timestamp: $bcEvent.timestamp, "
+            + "MERGE (t)-[:HAS_EVENT]->(bc: BamComplete {date: $bcEvent.date, "
             + "status: $bcEvent.status}) WITH s,t,bc RETURN t")
     Tempo mergeBamCompleteEventBySamplePrimaryId(@Param("primaryId") String primaryId,
             @Param("bcEvent") BamComplete bcEvent);

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <neo4j-ogm.version>3.2.14</neo4j-ogm.version>
     <junitjupiter.version>5.3.2</junitjupiter.version>
     <neo4j-java-driver.version>4.4.9</neo4j-java-driver.version>
-    <testcontainers.version>1.16.0</testcontainers.version>
+    <testcontainers.version>1.17.0</testcontainers.version>
     <!-- smile messaging and shared entities dependency versions -->
     <smile_messaging_java.group>com.github.mskcc</smile_messaging_java.group>
     <smile_messaging_java.version>1.3.11.RELEASE</smile_messaging_java.version>

--- a/service/src/main/java/org/mskcc/smile/service/impl/TempoMessageHandlingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/TempoMessageHandlingServiceImpl.java
@@ -71,15 +71,11 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                 try {
                     Entry<String, BamComplete> bcEvent = bamCompleteQueue.poll(100, TimeUnit.MILLISECONDS);
                     if (bcEvent != null) {
-                        LOG.info("Event exists");
-
                         // first determine if sample exists by the provided primary id
                         String primaryId = bcEvent.getKey();
                         BamComplete bamComplete = bcEvent.getValue();
                         if (sampleService.sampleExistsByPrimaryId(primaryId)) {
                             // merge and/or create tempo bam complete event to sample
-                            LOG.info("Sample exists");
-
                             Tempo tempo = tempoService.getTempoDataBySamplePrimaryId(primaryId);
                             if (tempo == null
                                     || !tempo.hasBamCompleteEvent(bamComplete)) {
@@ -87,7 +83,7 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                                         bamComplete);
                             }
                         } else {
-                            LOG.info("Sample does not exist");
+                            LOG.error("Sample with primary id: " + primaryId + " does not exist");
                         }
                     }
                 } catch (InterruptedException e) {
@@ -155,14 +151,9 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                     String bamCompleteJson = mapper.readValue(
                         new String(msg.getData(), StandardCharsets.UTF_8),
                         String.class);
-
-                    LOG.info("bamCompleteJson: " + bamCompleteJson);
-
                         Map<String, String> bamCompleteMap = mapper.readValue(bamCompleteJson, Map.class);
                     BamComplete bamComplete = new BamComplete(bamCompleteMap.get("date"),
                             bamCompleteMap.get("status"));
-                    
-                    LOG.info("\n\nBAM complete object: " + bamComplete.toString());
                     String primaryId = bamCompleteMap.get("primaryId");
                     Map.Entry<String, BamComplete> eventData =
                             new AbstractMap.SimpleImmutableEntry<>(primaryId, bamComplete);

--- a/service/src/main/java/org/mskcc/smile/service/impl/TempoMessageHandlingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/TempoMessageHandlingServiceImpl.java
@@ -159,7 +159,7 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                     LOG.info("bamCompleteJson: " + bamCompleteJson);
 
                         Map<String, String> bamCompleteMap = mapper.readValue(bamCompleteJson, Map.class);
-                    BamComplete bamComplete = new BamComplete(bamCompleteMap.get("timestamp"),
+                    BamComplete bamComplete = new BamComplete(bamCompleteMap.get("date"),
                             bamCompleteMap.get("status"));
                     
                     LOG.info("\n\nBAM complete object: " + bamComplete.toString());

--- a/service/src/test/java/org/mskcc/smile/service/CorrectCmoPatientIdHandlerTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/CorrectCmoPatientIdHandlerTest.java
@@ -41,7 +41,7 @@ public class CorrectCmoPatientIdHandlerTest {
     private SmilePatientService patientService;
 
     @Container
-    private static final Neo4jContainer databaseServer = new Neo4jContainer<>("neo4j:4.4")
+    private static final Neo4jContainer<?> databaseServer = new Neo4jContainer<>()
             .withEnv("NEO4J_dbms_security_procedures_unrestricted", "apoc.*,algo.*");
 
     @TestConfiguration

--- a/service/src/test/java/org/mskcc/smile/service/CorrectCmoPatientIdHandlerTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/CorrectCmoPatientIdHandlerTest.java
@@ -41,7 +41,7 @@ public class CorrectCmoPatientIdHandlerTest {
     private SmilePatientService patientService;
 
     @Container
-    private static final Neo4jContainer databaseServer = new Neo4jContainer<>()
+    private static final Neo4jContainer databaseServer = new Neo4jContainer<>("neo4j:4.4")
             .withEnv("NEO4J_dbms_security_procedures_unrestricted", "apoc.*,algo.*");
 
     @TestConfiguration

--- a/service/src/test/java/org/mskcc/smile/service/PatientServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/PatientServiceTest.java
@@ -40,7 +40,7 @@ public class PatientServiceTest {
     private SmilePatientService patientService;
 
     @Container
-    private static final Neo4jContainer databaseServer = new Neo4jContainer<>("neo4j:4.4")
+    private static final Neo4jContainer<?> databaseServer = new Neo4jContainer<>()
             .withEnv("NEO4J_dbms_security_procedures_unrestricted", "apoc.*,algo.*");
 
     @TestConfiguration

--- a/service/src/test/java/org/mskcc/smile/service/PatientServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/PatientServiceTest.java
@@ -40,7 +40,7 @@ public class PatientServiceTest {
     private SmilePatientService patientService;
 
     @Container
-    private static final Neo4jContainer databaseServer = new Neo4jContainer<>()
+    private static final Neo4jContainer databaseServer = new Neo4jContainer<>("neo4j:4.4")
             .withEnv("NEO4J_dbms_security_procedures_unrestricted", "apoc.*,algo.*");
 
     @TestConfiguration

--- a/service/src/test/java/org/mskcc/smile/service/RequestServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/RequestServiceTest.java
@@ -41,7 +41,7 @@ public class RequestServiceTest {
     private TempoService tempoService;
 
     @Container
-    private static final Neo4jContainer databaseServer = new Neo4jContainer<>()
+    private static final Neo4jContainer databaseServer = new Neo4jContainer<>("neo4j:4.4")
             .withEnv("NEO4J_dbms_security_procedures_unrestricted", "apoc.*,algo.*");
 
     @TestConfiguration

--- a/service/src/test/java/org/mskcc/smile/service/RequestServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/RequestServiceTest.java
@@ -41,7 +41,7 @@ public class RequestServiceTest {
     private TempoService tempoService;
 
     @Container
-    private static final Neo4jContainer databaseServer = new Neo4jContainer<>("neo4j:4.4")
+    private static final Neo4jContainer<?> databaseServer = new Neo4jContainer<>()
             .withEnv("NEO4J_dbms_security_procedures_unrestricted", "apoc.*,algo.*");
 
     @TestConfiguration

--- a/service/src/test/java/org/mskcc/smile/service/SampleServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/SampleServiceTest.java
@@ -51,7 +51,7 @@ public class SampleServiceTest {
     private TempoService tempoService;
 
     @Container
-    private static final Neo4jContainer databaseServer = new Neo4jContainer<>("neo4j:4.4")
+    private static final Neo4jContainer<?> databaseServer = new Neo4jContainer<>()
             .withEnv("NEO4J_dbms_security_procedures_unrestricted", "apoc.*,algo.*");
 
     @TestConfiguration

--- a/service/src/test/java/org/mskcc/smile/service/SampleServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/SampleServiceTest.java
@@ -51,7 +51,7 @@ public class SampleServiceTest {
     private TempoService tempoService;
 
     @Container
-    private static final Neo4jContainer databaseServer = new Neo4jContainer<>()
+    private static final Neo4jContainer databaseServer = new Neo4jContainer<>("neo4j:4.4")
             .withEnv("NEO4J_dbms_security_procedures_unrestricted", "apoc.*,algo.*");
 
     @TestConfiguration

--- a/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
@@ -150,6 +150,6 @@ public class TempoServiceTest {
     private BamComplete getBamCompleteEventData(String dataIdentifier) throws JsonProcessingException {
         MockJsonTestData mockData = mockDataUtils.mockedTempoDataMap.get(dataIdentifier);
         Map<String, String> bamCompleteMap = mapper.readValue(mockData.getJsonString(), Map.class);
-        return new BamComplete(bamCompleteMap.get("timestamp"), bamCompleteMap.get("status"));
+        return new BamComplete(bamCompleteMap.get("date"), bamCompleteMap.get("status"));
     }
 }

--- a/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
@@ -49,7 +49,7 @@ public class TempoServiceTest {
     private final ObjectMapper mapper = new ObjectMapper();
 
     @Container
-    private static final Neo4jContainer databaseServer = new Neo4jContainer<>("neo4j:4.4")
+    private static final Neo4jContainer<?> databaseServer = new Neo4jContainer<>()
             .withEnv("NEO4J_dbms_security_procedures_unrestricted", "apoc.*,algo.*");
 
     @TestConfiguration

--- a/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
@@ -49,7 +49,7 @@ public class TempoServiceTest {
     private final ObjectMapper mapper = new ObjectMapper();
 
     @Container
-    private static final Neo4jContainer databaseServer = new Neo4jContainer<>()
+    private static final Neo4jContainer databaseServer = new Neo4jContainer<>("neo4j:4.4")
             .withEnv("NEO4J_dbms_security_procedures_unrestricted", "apoc.*,algo.*");
 
     @TestConfiguration

--- a/service/src/test/resources/data/tempo/bam_complete_MOCKREQUEST1_B_1.json
+++ b/service/src/test/resources/data/tempo/bam_complete_MOCKREQUEST1_B_1.json
@@ -1,5 +1,5 @@
 {
   "primaryId": "MOCKREQUEST1_B_1",
-  "timestamp": "2023-12-25 14:20:50",
+  "date": "2023-12-25 14:20:50",
   "status": "PASS"
 }

--- a/service/src/test/resources/data/tempo/bam_complete_MOCKREQUEST1_B_2.json
+++ b/service/src/test/resources/data/tempo/bam_complete_MOCKREQUEST1_B_2.json
@@ -1,5 +1,5 @@
 {
   "primaryId": "MOCKREQUEST1_B_2",
-  "timestamp": "2023-12-25 16:11:20",
+  "date": "2023-12-25 16:11:20",
   "status": "PASS"
 }

--- a/service/src/test/resources/data/tempo/bam_complete_MOCKREQUEST1_B_3.json
+++ b/service/src/test/resources/data/tempo/bam_complete_MOCKREQUEST1_B_3.json
@@ -1,5 +1,5 @@
 {
   "primaryId": "MOCKREQUEST1_B_3",
-  "timestamp": "2023-12-25 13:44:10",
+  "date": "2023-12-25 13:44:10",
   "status": "FAIL"
 }

--- a/service/src/test/resources/data/tempo/bam_complete_MOCKREQUEST1_B_3_pass.json
+++ b/service/src/test/resources/data/tempo/bam_complete_MOCKREQUEST1_B_3_pass.json
@@ -1,5 +1,5 @@
 {
   "primaryId": "MOCKREQUEST1_B_3",
-  "timestamp": "2023-12-30 06:20:33",
+  "date": "2023-12-30 06:20:33",
   "status": "PASS"
 }

--- a/service/src/test/resources/data/tempo/bam_complete_MOCKREQUEST1_B_4.json
+++ b/service/src/test/resources/data/tempo/bam_complete_MOCKREQUEST1_B_4.json
@@ -1,5 +1,5 @@
 {
   "primaryId": "MOCKREQUEST1_B_4",
-  "timestamp": "2023-12-25 11:33:44",
+  "date": "2023-12-25 11:33:44",
   "status": "PASS"
 }


### PR DESCRIPTION
# Fix BamComplete & Specify Neo4j Docker Image Version

This PR is a follow-up to #1084 and handles a bug that occurs when Java constructs the Neo4j query `mergeBamCompleteEventBySamplePrimaryId`. An issue occurs when the date String value inside of `BamComplete.timestamp` gets inferred and automatically converted to `BamComplete.date` during the query construction process. This PR renames the property `timestamp` to `date` to avoid this conversion and makes our code clearer.

As a side task, this PR also specifies the Neo4j Docker image version that is used as part of the unit tests. Without specifying, `TestContainer` falls back on a dated Neo4j image version that isn't compatible with the ARM64 architecture. This PR updates the image version to one that supports both AMD and ARM.

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Data checks:**
Updates were made to the mocked incoming request data and/or mocked published request data:
- [ ] [smile-server test data](https://github.com/mskcc/smile-server/tree/master/service/src/test/resources/data)
- [ ] [smile-commons test data](https://github.com/mskcc/smile-commons/tree/master/src/test/resources/data)
- [ ] [smile-label-generator test data](https://github.com/mskcc/smile-label-generator/tree/master/src/test/resources/data)
- [ ] [smile-request-filter test data](https://github.com/mskcc/smile-request-filter/tree/master/src/test/resources/data)

**Code checks:**
- [ ] Endpoints were tested to ensure their integrity.
- [ ] Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.
- [ ] Unit tests were updated in relation to updates to the mocked test data.

### II. Neo4j models and database schema checklist:
- [ ] Neo4j persistence models were changed.
- [ ] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]

### III. Message handlers checklist:
- [ ] Changes in this PR affect the workflow of incoming messages.
- [ ] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [ ] Unit tests were added to ensure messages are handled as expected.

If no unit tests were updated or added, then please explain why: [insert details here]

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, local docker, dev server, production]
- Neo4j [local, local docker, dev server, production]
- SMILE Server [local, local docker, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, smile publisher tool, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### IV. Configuration and/or permissions checklist:
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.

---
### Screenshots

---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
