### PR TITLE
Additional fields for sample tempo data

### DIFF
--- a/model/src/main/java/org/mskcc/smile/model/tempo/CohortComplete.java
+++ b/model/src/main/java/org/mskcc/smile/model/tempo/CohortComplete.java
@@ -3,7 +3,6 @@ package org.mskcc.smile.model.tempo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/model/src/main/java/org/mskcc/smile/model/tempo/Tempo.java
+++ b/model/src/main/java/org/mskcc/smile/model/tempo/Tempo.java
@@ -18,6 +18,8 @@ import org.neo4j.ogm.annotation.Relationship;
 public class Tempo implements Serializable {
     @Id @GeneratedValue
     private Long id;
+    private String custodianInformation;
+    private String accessLevel;
     @Relationship(type = "HAS_EVENT", direction = Relationship.OUTGOING)
     private List<BamComplete> bamCompleteEvents;
     @Relationship(type = "HAS_EVENT", direction = Relationship.OUTGOING)
@@ -29,12 +31,32 @@ public class Tempo implements Serializable {
 
     public Tempo() {}
 
+    public Tempo(SmileSample sample) {
+        this.sample = sample;
+    }
+
     public Long getId() {
         return id;
     }
 
     public void setId(Long id) {
         this.id = id;
+    }
+
+    public String getCustodianInformation() {
+        return custodianInformation;
+    }
+
+    public void setCustodianInformation(String custodianInformation) {
+        this.custodianInformation = custodianInformation;
+    }
+
+    public String getAccessLevel() {
+        return accessLevel;
+    }
+
+    public void setAccessLevel(String accessLevel) {
+        this.accessLevel = accessLevel;
     }
 
     /**

--- a/service/src/main/java/org/mskcc/smile/service/SmileSampleService.java
+++ b/service/src/main/java/org/mskcc/smile/service/SmileSampleService.java
@@ -1,6 +1,5 @@
 package org.mskcc.smile.service;
 
-import java.text.ParseException;
 import java.util.List;
 import java.util.UUID;
 import org.mskcc.smile.model.SampleMetadata;
@@ -26,7 +25,7 @@ public interface SmileSampleService {
     List<PublishedSmileSample> getPublishedSmileSamplesByCmoPatientId(String cmoPatientId)
             throws Exception;
     List<SmileSample> getSamplesByCmoPatientId(String cmoPatientId) throws Exception;
-    SmileSample getDetailedSmileSample(SmileSample sample) throws ParseException;
+    SmileSample getDetailedSmileSample(SmileSample sample) throws Exception;
     SmileSample getClinicalSampleByDmpId(String dmpId) throws Exception;
     List<SmileSample> getSamplesByCategoryAndCmoPatientId(String cmoPatientId,
             String sampleCategory) throws Exception;

--- a/service/src/main/java/org/mskcc/smile/service/TempoService.java
+++ b/service/src/main/java/org/mskcc/smile/service/TempoService.java
@@ -11,10 +11,11 @@ import org.mskcc.smile.model.tempo.Tempo;
  * @author ochoaa
  */
 public interface TempoService {
-    Tempo saveTempoData(Tempo tempo);
-    Tempo getTempoDataBySampleId(SmileSample smileSample);
-    Tempo getTempoDataBySamplePrimaryId(String primaryId);
-    Tempo mergeBamCompleteEventBySamplePrimaryId(String primaryId, BamComplete bamComplete);
-    Tempo mergeQcCompleteEventBySamplePrimaryId(String primaryId, QcComplete qcComplete);
-    Tempo mergeMafCompleteEventBySamplePrimaryId(String primaryId, MafComplete mafComplete);
+    Tempo saveTempoData(Tempo tempo) throws Exception;
+    Tempo getTempoDataBySampleId(SmileSample smileSample) throws Exception;
+    Tempo getTempoDataBySamplePrimaryId(String primaryId) throws Exception;
+    Tempo mergeBamCompleteEventBySamplePrimaryId(String primaryId, BamComplete bamComplete) throws Exception;
+    Tempo mergeQcCompleteEventBySamplePrimaryId(String primaryId, QcComplete qcComplete) throws Exception;
+    Tempo mergeMafCompleteEventBySamplePrimaryId(String primaryId, MafComplete mafComplete) throws Exception;
+    Tempo initAndSaveDefaultTempoData(String primaryId) throws Exception;
 }

--- a/service/src/main/java/org/mskcc/smile/service/impl/CohortCompleteServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/CohortCompleteServiceImpl.java
@@ -11,6 +11,7 @@ import org.mskcc.smile.model.tempo.CohortComplete;
 import org.mskcc.smile.persistence.neo4j.CohortCompleteRepository;
 import org.mskcc.smile.service.CohortCompleteService;
 import org.mskcc.smile.service.SmileSampleService;
+import org.mskcc.smile.service.TempoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -22,10 +23,15 @@ import org.springframework.stereotype.Component;
 public class CohortCompleteServiceImpl implements CohortCompleteService {
     @Autowired
     private JsonComparator jsonComparator;
+
     @Autowired
     private CohortCompleteRepository cohortCompleteRepository;
+
     @Autowired
     private SmileSampleService sampleService;
+
+    @Autowired
+    private TempoService tempoService;
 
     private ObjectMapper mapper = new ObjectMapper();
 
@@ -39,6 +45,10 @@ public class CohortCompleteServiceImpl implements CohortCompleteService {
         for (String primaryId : samplePrimaryIds) {
             // confirm sample exists by primary id and then link to cohort
             if (sampleService.sampleExistsByPrimaryId(primaryId)) {
+                // init default tempo data for sample if sample does not already have tempo data
+                if (tempoService.getTempoDataBySamplePrimaryId(primaryId) == null) {
+                    tempoService.initAndSaveDefaultTempoData(primaryId);
+                }
                 cohortCompleteRepository.addCohortSampleRelationship(cohort.getCohortId(), primaryId);
             }
         }

--- a/service/src/main/java/org/mskcc/smile/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/SampleServiceImpl.java
@@ -403,7 +403,7 @@ public class SampleServiceImpl implements SmileSampleService {
     }
 
     @Override
-    public SmileSample getDetailedSmileSample(SmileSample sample) throws ParseException {
+    public SmileSample getDetailedSmileSample(SmileSample sample) throws Exception {
         sample.setSampleMetadataList(getSampleMetadataWithStatus(
                 sampleRepository.findAllSampleMetadataListBySampleId(
                 sample.getSmileSampleId())));

--- a/service/src/main/java/org/mskcc/smile/service/impl/TempoServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/TempoServiceImpl.java
@@ -1,14 +1,19 @@
 package org.mskcc.smile.service.impl;
 
+import org.apache.logging.log4j.util.Strings;
+import org.mskcc.smile.model.SmileRequest;
 import org.mskcc.smile.model.SmileSample;
 import org.mskcc.smile.model.tempo.BamComplete;
 import org.mskcc.smile.model.tempo.MafComplete;
 import org.mskcc.smile.model.tempo.QcComplete;
 import org.mskcc.smile.model.tempo.Tempo;
 import org.mskcc.smile.persistence.neo4j.TempoRepository;
+import org.mskcc.smile.service.SmileRequestService;
+import org.mskcc.smile.service.SmileSampleService;
 import org.mskcc.smile.service.TempoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  *
@@ -20,39 +25,90 @@ public class TempoServiceImpl implements TempoService {
     @Autowired
     private TempoRepository tempoRepository;
 
+    @Autowired
+    private SmileSampleService sampleService;
+
+    @Autowired
+    private SmileRequestService requestService;
+
     @Override
-    public Tempo saveTempoData(Tempo tempo) {
+    @Transactional(rollbackFor = {Exception.class})
+    public Tempo saveTempoData(Tempo tempo) throws Exception {
+        // first instance of tempo data for a given sample means we need to resolve the
+        // custodian information and data access level
+        SmileSample sample = tempo.getSmileSample();
+        SmileRequest request = requestService.getRequestBySample(sample);
+        String custodianInformation = Strings.isBlank(request.getPiEmail())
+                ? request.getInvestigatorEmail() : request.getPiEmail();
+        tempo.setCustodianInformation(custodianInformation);
+
+        // if backfilling data then access level might already be present in incoming data
+        if (Strings.isBlank(tempo.getAccessLevel())) {
+            tempo.setAccessLevel("MSKEmbargo");
+        }
+
         return tempoRepository.save(tempo);
     }
 
     @Override
-    public Tempo getTempoDataBySampleId(SmileSample smileSample) {
+    public Tempo getTempoDataBySampleId(SmileSample smileSample) throws Exception {
         Tempo tempo = tempoRepository.findTempoBySmileSampleId(smileSample.getSmileSampleId());
+        if (tempo == null) {
+            return null;
+        }
         return getDetailedTempoData(tempo);
     }
 
     @Override
-    public Tempo getTempoDataBySamplePrimaryId(String primaryId) {
+    public Tempo getTempoDataBySamplePrimaryId(String primaryId) throws Exception {
         Tempo tempo = tempoRepository.findTempoBySamplePrimaryId(primaryId);
+        if (tempo == null) {
+            return null;
+        }
         return getDetailedTempoData(tempo);
     }
 
     @Override
-    public Tempo mergeBamCompleteEventBySamplePrimaryId(String primaryId, BamComplete bamCompleteEvent) {
+    public Tempo mergeBamCompleteEventBySamplePrimaryId(String primaryId, BamComplete bamCompleteEvent)
+            throws Exception {
+        if (getTempoDataBySamplePrimaryId(primaryId) == null) {
+            initAndSaveDefaultTempoData(primaryId);
+        }
         Tempo tempo = tempoRepository.mergeBamCompleteEventBySamplePrimaryId(primaryId, bamCompleteEvent);
         return getDetailedTempoData(tempo);
     }
 
     @Override
-    public Tempo mergeQcCompleteEventBySamplePrimaryId(String primaryId, QcComplete qcCompleteEvent) {
+    public Tempo mergeQcCompleteEventBySamplePrimaryId(String primaryId, QcComplete qcCompleteEvent)
+            throws Exception {
+        if (getTempoDataBySamplePrimaryId(primaryId) == null) {
+            initAndSaveDefaultTempoData(primaryId);
+        }
         Tempo tempo = tempoRepository.mergeQcCompleteEventBySamplePrimaryId(primaryId, qcCompleteEvent);
         return getDetailedTempoData(tempo);
     }
 
     @Override
-    public Tempo mergeMafCompleteEventBySamplePrimaryId(String primaryId, MafComplete mafCompleteEvent) {
+    public Tempo mergeMafCompleteEventBySamplePrimaryId(String primaryId, MafComplete mafCompleteEvent)
+            throws Exception {
+        if (getTempoDataBySamplePrimaryId(primaryId) == null) {
+            initAndSaveDefaultTempoData(primaryId);
+        }
         Tempo tempo = tempoRepository.mergeMafCompleteEventBySamplePrimaryId(primaryId, mafCompleteEvent);
         return getDetailedTempoData(tempo);
+    }
+
+    @Override
+    public Tempo initAndSaveDefaultTempoData(String primaryId) throws Exception {
+        SmileSample sample = sampleService.getSampleByInputId(primaryId);
+        Tempo tempo = new Tempo(sample);
+        SmileRequest request = requestService.getRequestBySample(sample);
+        String custodianInformation = Strings.isBlank(request.getPiEmail())
+                ? request.getInvestigatorEmail() : request.getPiEmail();
+        // using default of MSKEmbargo since we're making a brand new tempo event
+        tempo.setCustodianInformation(custodianInformation);
+        tempo.setAccessLevel("MSKEmbargo");
+        return tempoRepository.save(tempo);
     }
 
     private Tempo getDetailedTempoData(Tempo tempo) {

--- a/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
@@ -165,6 +165,8 @@ public class TempoServiceTest {
         // and distinguishes them from other event types
         Tempo tempoAfterSave = tempoService.getTempoDataBySamplePrimaryId(igoId);
         Assertions.assertThat(tempoAfterSave.getMafCompleteEvents().size()).isEqualTo(1);
+        Assertions.assertThat(tempoAfterSave.getCustodianInformation()).isNotBlank();
+        Assertions.assertThat(tempoAfterSave.getAccessLevel()).isNotBlank();
     }
 
     @Test
@@ -176,6 +178,8 @@ public class TempoServiceTest {
         // and distinguishes them from other event types
         Tempo tempoAfterSave = tempoService.getTempoDataBySamplePrimaryId(igoId);
         Assertions.assertThat(tempoAfterSave.getQcCompleteEvents().size()).isEqualTo(1);
+        Assertions.assertThat(tempoAfterSave.getCustodianInformation()).isNotBlank();
+        Assertions.assertThat(tempoAfterSave.getAccessLevel()).isNotBlank();
     }
 
     @Test


### PR DESCRIPTION
# Additional fields for cohort sample tempo data

Briefly describe changes proposed in this pull request:

Fields are stored at the Sample Tempo node level. On first import of
any Tempo event, a Sample will get a default Tempo node initialized with
custodian information and access level set with default values.

Default value for custodian information is the PI email or investigator email
from the Request that a Sample belongs to and the access level is set to MSKEmbargo.

When backfilling data, the access level will need to resolve the earliest delivery
date for a given sample and calculate whether the current date falls within the
embargo date threshold.

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

n/a

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Data checks:** n/a - no changes required to mock data
```
Updates were made to the mocked incoming request data and/or mocked published request data:
- [ ] [smile-server test data](https://github.com/mskcc/smile-server/tree/master/service/src/test/resources/data)
- [ ] [smile-commons test data](https://github.com/mskcc/smile-commons/tree/master/src/test/resources/data)
- [ ] [smile-label-generator test data](https://github.com/mskcc/smile-label-generator/tree/master/src/test/resources/data)
- [ ] [smile-request-filter test data](https://github.com/mskcc/smile-request-filter/tree/master/src/test/resources/data)
```
**Code checks:** n/a - changes do not affect web layer
```
- [ ] Endpoints were tested to ensure their integrity.
- [ ] Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.
- [ ] Unit tests were updated in relation to updates to the mocked test data.
```
### II. Neo4j models and database schema checklist:
- [x] Neo4j persistence models were changed.
- [x] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]

### III. Message handlers checklist: n/a - workflow unaffected by changes
```
- [ ] Changes in this PR affect the workflow of incoming messages.
- [ ] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [ ] Unit tests were added to ensure messages are handled as expected.
```
~~If no unit tests were updated or added, then please explain why: [insert details here]~~ Unit tests **were** updated

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, local docker, dev server, production]
- Neo4j [local, local docker, dev server, production]
- SMILE Server [local, local docker, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, smile publisher tool, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### IV. Configuration and/or permissions checklist: n/a
```
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.
```

---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
