### PR TITLE
Change default value of custodianInformation on TEMPO node creation

### DIFF
--- a/service/src/main/java/org/mskcc/smile/service/impl/TempoServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/TempoServiceImpl.java
@@ -39,13 +39,13 @@ public class TempoServiceImpl implements TempoService {
         // custodian information and data access level
         SmileSample sample = tempo.getSmileSample();
         SmileRequest request = requestService.getRequestBySample(sample);
-        String custodianInformation = Strings.isBlank(request.getPiEmail())
-                ? request.getInvestigatorEmail() : request.getPiEmail();
+        String custodianInformation = Strings.isBlank(request.getLabHeadName())
+                ? request.getLabHeadName() : request.getInvestigatorName();
         tempo.setCustodianInformation(custodianInformation);
 
         // if backfilling data then access level might already be present in incoming data
         if (Strings.isBlank(tempo.getAccessLevel())) {
-            tempo.setAccessLevel("MSKEmbargo");
+            tempo.setAccessLevel("MSK Embargo");
         }
 
         return tempoRepository.save(tempo);


### PR DESCRIPTION
Quick fix to change the default values of a sample Tempo node's:
- custodianInformation
- accessLevel