### PR TITLE
Remove default Tempo data for Normal samples on import

### DIFF
--- a/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
@@ -218,6 +218,39 @@ public class TempoServiceTest {
         Assertions.assertThat(hasUpdates).isTrue();
     }
 
+    @Test
+    public void testNormalSampleTumorSampleTempoImportDefaults() throws Exception {
+        String requestId = "MOCKREQUEST1_B";
+
+        // sample MOCKREQUEST1_B_2 is "Normal" which should not have default values set to
+        // tempo.custodianInformation or tempo.accessLevel
+        String igoId2 = "MOCKREQUEST1_B_2";
+        Tempo tempo2 = new Tempo();
+        tempo2.addBamCompleteEvent(getBamCompleteEventData("mockBamCompleteSampleB2"));
+        SmileSample sample2 = sampleService.getResearchSampleByRequestAndIgoId(requestId, igoId2);
+        tempo2.setSmileSample(sample2); // this should link the tempo node to the correct sample node
+        tempoService.saveTempoData(tempo2);
+
+        // assert data persisted correctly
+        Tempo tempoAfterSave2 = tempoService.getTempoDataBySamplePrimaryId(igoId2);
+        Assertions.assertThat(tempoAfterSave2.getCustodianInformation()).isNullOrEmpty();
+        Assertions.assertThat(tempoAfterSave2.getAccessLevel()).isNullOrEmpty();
+
+        // sample MOCKREQUEST1_B_3 is "Tumor" which should have default values set to
+        // tempo.custodianInformation and tempo.accessLevel
+        String igoId3 = "MOCKREQUEST1_B_3";
+        Tempo tempo3 = new Tempo();
+        tempo3.addBamCompleteEvent(getBamCompleteEventData("mockBamCompleteSampleB3"));
+        SmileSample sample3 = sampleService.getResearchSampleByRequestAndIgoId(requestId, igoId3);
+        tempo3.setSmileSample(sample3); // this should link the tempo node to the correct sample node
+        tempoService.saveTempoData(tempo3);
+
+        // assert data persisted correctly
+        Tempo tempoAfterSave3 = tempoService.getTempoDataBySamplePrimaryId(igoId3);
+        Assertions.assertThat(tempoAfterSave3.getCustodianInformation()).isNotBlank();
+        Assertions.assertThat(tempoAfterSave3.getAccessLevel()).isNotBlank();
+    }
+
     private CohortCompleteJson getCohortEventData(String dataIdentifier) throws JsonProcessingException {
         MockJsonTestData mockData = mockDataUtils.mockedTempoDataMap.get(dataIdentifier);
         CohortCompleteJson cohortCompleteData = mapper.readValue(mockData.getJsonString(),


### PR DESCRIPTION
# Remove default Tempo data for Normal samples on import

Briefly describe changes proposed in this pull request:

Normal samples do not have custodian information or access levels associated with them. These changes
allow it so that only non-Normal samples have Tempo data initialized with custodian information and access level info.


---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Data checks:**
Updates were made to the mocked incoming request data and/or mocked published request data:
- [x] [smile-server test data](https://github.com/mskcc/smile-server/tree/master/service/src/test/resources/data)
- [ ] [smile-commons test data](https://github.com/mskcc/smile-commons/tree/master/src/test/resources/data)
- [ ] [smile-label-generator test data](https://github.com/mskcc/smile-label-generator/tree/master/src/test/resources/data)
- [ ] [smile-request-filter test data](https://github.com/mskcc/smile-request-filter/tree/master/src/test/resources/data)

**Code checks:** n/a
```
- [ ] Endpoints were tested to ensure their integrity.
- [ ] Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.
- [ ] Unit tests were updated in relation to updates to the mocked test data.
```
### II. Neo4j models and database schema checklist: n/a
```
- [ ] Neo4j persistence models were changed.
- [ ] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]
```
### III. Message handlers checklist: n/a
```
- [ ] Changes in this PR affect the workflow of incoming messages.
- [ ] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [ ] Unit tests were added to ensure messages are handled as expected.
```
If no unit tests were updated or added, then please explain why: New test added to confirm the correct behavior occurs when a normal sample has tempo data imported and when a tumor sample has tempo data imported.

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, local docker, dev server, production]
- Neo4j [local, local docker, dev server, production]
- SMILE Server [local, local docker, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, smile publisher tool, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### IV. Configuration and/or permissions checklist: n/a
```
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.
```

---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
