### PR TITLE
Flatten pmUsers and endUsers on CohortComplete nodes

### DIFF
--- a/model/src/main/java/org/mskcc/smile/model/converter/ArrayStringConverter.java
+++ b/model/src/main/java/org/mskcc/smile/model/converter/ArrayStringConverter.java
@@ -1,0 +1,41 @@
+package org.mskcc.smile.model.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.neo4j.ogm.typeconversion.AttributeConverter;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class ArrayStringConverter implements AttributeConverter<List<String>, String> {
+    private final ObjectMapper mapper = new ObjectMapper();
+    private static final Log LOG = LogFactory.getLog(ArrayStringConverter.class);
+
+    @Override
+    public String toGraphProperty(List<String> value) {
+        String toReturn = null;
+        try {
+            toReturn = mapper.writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            LOG.error(ex);
+        }
+        return toReturn;
+    }
+
+    @Override
+    public List<String> toEntityAttribute(String value) {
+        List<String> toReturn = null;
+        try {
+            toReturn = Arrays.asList(mapper.readValue(value, String[].class));
+        } catch (Exception ex) {
+            LOG.error(ex);
+        }
+        return toReturn;
+    }
+
+}

--- a/model/src/main/java/org/mskcc/smile/model/tempo/CohortComplete.java
+++ b/model/src/main/java/org/mskcc/smile/model/tempo/CohortComplete.java
@@ -6,10 +6,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.mskcc.smile.model.converter.ArrayStringConverter;
 import org.mskcc.smile.model.tempo.json.CohortCompleteJson;
 import org.neo4j.ogm.annotation.GeneratedValue;
 import org.neo4j.ogm.annotation.Id;
 import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.typeconversion.Convert;
 
 /**
  *
@@ -23,7 +25,9 @@ public class CohortComplete implements Serializable, Comparable<CohortComplete> 
     private String date;
     private String status;
     private String type;
+    @Convert(ArrayStringConverter.class)
     private List<String> endUsers;
+    @Convert(ArrayStringConverter.class)
     private List<String> pmUsers;
     private String projectTitle;
     private String projectSubtitle;

--- a/scripts/migrate.cypher
+++ b/scripts/migrate.cypher
@@ -150,3 +150,14 @@ RETURN true
 MATCH (t: Tempo)
 SET t.smileTempoId = apoc.create.uuid()
 RETURN true
+
+// flatten pmUsers and endUsers on CohortComplete nodes
+MATCH (cc:CohortComplete)
+WITH cc, REDUCE(x="", v IN cc.pmUsers | x + v + ", ") AS newPmUsers
+SET cc.pmUsers = LEFT(newPmUsers, SIZE(newPmUsers)-2)
+RETURN cc
+
+MATCH (cc:CohortComplete)
+WITH cc, REDUCE(x="", v IN cc.endUsers | x + v + ", ") AS newEndUsers
+SET cc.endUsers = LEFT(newEndUsers, SIZE(newEndUsers)-2)
+RETURN cc


### PR DESCRIPTION
- Flatten pmUsers and endUsers on CohortComplete nodes



---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Data checks:** ~ n/a
```
Updates were made to the mocked incoming request data and/or mocked published request data:
- [ ] [smile-server test data](https://github.com/mskcc/smile-server/tree/master/service/src/test/resources/data)
- [ ] [smile-commons test data](https://github.com/mskcc/smile-commons/tree/master/src/test/resources/data)
- [ ] [smile-label-generator test data](https://github.com/mskcc/smile-label-generator/tree/master/src/test/resources/data)
- [ ] [smile-request-filter test data](https://github.com/mskcc/smile-request-filter/tree/master/src/test/resources/data)
```
**Code checks:** n/a
```
- [ ] Endpoints were tested to ensure their integrity.
- [ ] Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.
- [ ] Unit tests were updated in relation to updates to the mocked test data.
```

### II. Neo4j models and database schema checklist: 
- [x] Neo4j persistence models were changed.
- [x] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]


![image](https://github.com/mskcc/smile-server/assets/15623749/a579e8e5-3152-4147-a039-de23d51d7b23)


![image](https://github.com/mskcc/smile-server/assets/15623749/8bdad4fa-cde4-4055-8c11-6bd9618ea183)

### III. Message handlers checklist: n/a
```
- [ ] Changes in this PR affect the workflow of incoming messages.
- [ ] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [ ] Unit tests were added to ensure messages are handled as expected.
```

If no unit tests were updated or added, then please explain why: [insert details here]

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, local docker, dev server, production]
- Neo4j [local, local docker, dev server, production]
- SMILE Server [local, local docker, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, smile publisher tool, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### IV. Configuration and/or permissions checklist: n/a
```
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.
```
---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
