### PR TITLE
Allow flexible input sample ids for the TEMPO pipeline

### DIFF
--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileSampleRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileSampleRepository.java
@@ -130,9 +130,6 @@ public interface SmileSampleRepository extends Neo4jRepository<SmileSample, UUID
     SmileSample updateRevisableBySampleId(@Param("smileSampleId") UUID smileSampleId,
             @Param("revisable") Boolean revisable);
 
-    @Query("MATCH (s: Sample)-[:HAS_METADATA]->(sm: SampleMetadata {primaryId: $primaryId}) RETURN s")
-    SmileSample sampleExistsByPrimaryId(@Param("primaryId") String primaryId);
-
     @Query("MATCH (c: Cohort {cohortId: $cohortId})-[:HAS_COHORT_SAMPLE]->"
             + "(s: Sample) "
             + "RETURN s")

--- a/service/src/main/java/org/mskcc/smile/service/SmileSampleService.java
+++ b/service/src/main/java/org/mskcc/smile/service/SmileSampleService.java
@@ -31,8 +31,8 @@ public interface SmileSampleService {
             String sampleCategory) throws Exception;
     void updateSamplePatientRelationship(UUID smileSampleId, UUID smilePatientId);
     List<SmileSampleIdMapping> getSamplesByDate(String inputDate);
-    SmileSample getSampleByInputId(String inputId);
+    SmileSample getSampleByInputId(String inputId) throws Exception;
     void createSampleRequestRelationship(UUID smileSampleId, UUID smileRequestId);
-    Boolean sampleExistsByPrimaryId(String primaryId);
+    Boolean sampleExistsByInputId(String primaryId);
     List<SmileSample> getSamplesByCohortId(String cohortId)throws Exception;
 }

--- a/service/src/main/java/org/mskcc/smile/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/SampleServiceImpl.java
@@ -478,8 +478,12 @@ public class SampleServiceImpl implements SmileSampleService {
     }
 
     @Override
-    public SmileSample getSampleByInputId(String inputId) {
-        return sampleRepository.findSampleByInputId(inputId);
+    public SmileSample getSampleByInputId(String inputId) throws Exception {
+        SmileSample sample = sampleRepository.findSampleByInputId(inputId);
+        if (sample != null) {
+            return getDetailedSmileSample(sample);
+        }
+        return null;
     }
 
     @Override
@@ -488,8 +492,8 @@ public class SampleServiceImpl implements SmileSampleService {
     }
 
     @Override
-    public Boolean sampleExistsByPrimaryId(String primaryId) {
-        return (sampleRepository.sampleExistsByPrimaryId(primaryId) != null);
+    public Boolean sampleExistsByInputId(String inputId) {
+        return (sampleRepository.findSampleByInputId(inputId) != null);
     }
 
     @Override


### PR DESCRIPTION
# Allow flexible input sample ids for TEMPO pipeline

Briefly describe changes proposed in this pull request:
- Sample IDs provided can now be either a primary ID or CMO sample label

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Data checks:**
Updates were made to the mocked incoming request data and/or mocked published request data:
~~- [ ] [smile-server test data](https://github.com/mskcc/smile-server/tree/master/service/src/test/resources/data)~~
~~- [ ] [smile-commons test data](https://github.com/mskcc/smile-commons/tree/master/src/test/resources/data)~~
~~- [ ] [smile-label-generator test data](https://github.com/mskcc/smile-label-generator/tree/master/src/test/resources/data)~~
~~- [ ] [smile-request-filter test data](https://github.com/mskcc/smile-request-filter/tree/master/src/test/resources/data)~~

**Code checks:**
- [ ] Endpoints were tested to ensure their integrity.
- [ ] Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.
- [ ] Unit tests were updated in relation to updates to the mocked test data.

### II. Neo4j models and database schema checklist:
~~- [ ] Neo4j persistence models were changed.~~
~~- [ ] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]~~

### III. Message handlers checklist:
~~- [ ] Changes in this PR affect the workflow of incoming messages.~~
- [x] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [ ] Unit tests were added to ensure messages are handled as expected.

If no unit tests were updated or added, then please explain why: Existing unit tests still work.

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, local docker, dev server, production]
- Neo4j [local, local docker, dev server, production]
- SMILE Server [local, local docker, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, smile publisher tool, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### IV. Configuration and/or permissions checklist: 
~~- [ ] New topics were introduced.~~
~~- [ ] The topics and appropriate permissions were updated in [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).~~
~~- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).~~
~~- [ ] Account credentials and keys were shared with the appropriate parties.~~

---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
