### PR TITLE
Add request-reply handler for fetching samples by alt ID

### DIFF
--- a/service/src/main/java/org/mskcc/smile/service/RequestReplyHandlingService.java
+++ b/service/src/main/java/org/mskcc/smile/service/RequestReplyHandlingService.java
@@ -6,6 +6,7 @@ public interface RequestReplyHandlingService {
     void initialize(Gateway gateway) throws Exception;
     void patientSamplesHandler(String patientId, String replyTo) throws Exception;
     void samplesByCmoLabelHandler(String cmoLabel, String replyTo) throws Exception;
+    void samplesByAltIdHandler(String cmoLabel, String replyTo) throws Exception;
     void crdbMappingHandler(String inputId, String replyTo) throws Exception;
     void shutdown() throws Exception;
 }

--- a/service/src/test/java/org/mskcc/smile/service/SampleServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/SampleServiceTest.java
@@ -158,6 +158,12 @@ public class SampleServiceTest {
         SmileRequest request8 = RequestDataFactory.buildNewLimsRequestFromJson(request8Data.getJsonString());
         requestService.saveRequest(request8);
 
+        // mock request id: MOCKREQUEST9_D
+        MockJsonTestData request9Data = mockDataUtils.mockedRequestJsonDataMap
+                .get("mockIncomingRequest9DupAltIds");
+        SmileRequest request9 = RequestDataFactory.buildNewLimsRequestFromJson(request9Data.getJsonString());
+        requestService.saveRequest(request9);
+
         //persist all mocked clinical data
         for (MockJsonTestData mockJsonTestData : mockDataUtils.mockedDmpMetadataMap.values()) {
             DmpSampleMetadata dmpSample = mapper.readValue(mockJsonTestData.getJsonString(),
@@ -713,5 +719,12 @@ public class SampleServiceTest {
         List<SmileSample> samplesMatchingLabels = sampleService.getSamplesByCmoSampleName(cmoLabel);
         Assertions.assertEquals(2, samplesMatchingLabels.size());
     }
-}
 
+    @Test
+    @Order(24)
+    public void testDuplicateAltIds() throws Exception {
+        String altId = "AB9-ABC";
+        List<SmileSample> samplesMatchingAltIds = sampleService.getSamplesByAltId(altId);
+        Assertions.assertEquals(2, samplesMatchingAltIds.size());
+    }
+}

--- a/service/src/test/resources/data/incoming_requests/mocked_request9_duplicate_alt_ids.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request9_duplicate_alt_ids.json
@@ -1,0 +1,152 @@
+{
+  "requestId": "MOCKREQUEST9_D",
+  "recipe": "GENESET101_BAITS",
+  "projectManagerName": "Bar, Foo",
+  "piEmail": "request8pi@mskcc.org",
+  "labHeadName": "Foo Bar",
+  "labHeadEmail": "request1pi@mskcc.org",
+  "investigatorName": "John Smith",
+  "investigatorEmail": "smithj@mskcc.org",
+  "dataAnalystName": "Poin Dexter",
+  "dataAnalystEmail": "dexterp@mskcc.org",
+  "otherContactEmails": "dexterp@mskcc.org",
+  "dataAccessEmails": "",
+  "qcAccessEmails": "",
+  "isCmoRequest": true,
+  "bicAnalysis": false,
+  "samples": [
+    {
+      "altId": "AB9-ABC",
+      "cmoSampleName": "",
+      "sampleName": "XXX002_P3_12345_L1",
+      "cmoSampleClass": "Primary",
+      "oncoTreeCode": "CLL",
+      "collectionYear": "",
+      "tubeId": "",
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": "IDT29",
+          "barcodeIndex": "ATTGAGGA",
+          "libraryIgoId": "MOCKREQUEST9_D_1_1_1_1",
+          "libraryVolume": 35.0,
+          "libraryConcentrationNgul": 34.8,
+          "captureConcentrationNm": "11.49425287356322",
+          "captureInputNg": "400.0",
+          "captureName": "Pool-MOCKREQUEST9_D-Tube7_1",
+          "runs": [
+            {
+              "runMode": "HiSeq High Output",
+              "runId": "RUNID_0123",
+              "flowCellId": "X5KL2KKAY",
+              "readLength": "",
+              "runDate": "2018-06-05",
+              "flowCellLanes": [
+                5
+              ],
+              "fastqs": [
+                "/FASTQ/Project_MOCKREQUEST9_D/Sample_XXX002_P3_12345_L1_IGO_MOCKREQUEST9_D_1/XXX002_P3_12345_L1_IGO_MOCKREQUEST9_D_1_S82_R1_001.fastq.gz",
+                "/FASTQ/Project_MOCKREQUEST9_D/Sample_XXX002_P3_12345_L1_IGO_MOCKREQUEST9_D_1/XXX002_P3_12345_L1_IGO_MOCKREQUEST9_D_1_S82_R2_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "cmoPatientId": "C-MP636AP",
+      "igoId": "MOCKREQUEST9_D_1",
+      "investigatorSampleId": "NORMAL_SAMPLE8_123",
+      "species": "Human",
+      "sex": "F",
+      "tumorOrNormal": "Normal",
+      "preservation": "Frozen",
+      "specimenType": "PDX",
+      "sampleOrigin": "Tissue",
+      "tissueLocation": "",
+      "baitSet": "GENESET101_BAITS",
+      "igoComplete": true,
+      "cmoSampleIdFields": {
+        "naToExtract": "",
+        "sampleType": "Tissue",
+        "normalizedPatientId": "MRN_REDACTED",
+        "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
+      }
+    },
+    {
+      "altId": "AB9-ABC",
+      "cmoSampleName": "",
+      "sampleName": "01-0012345a",
+      "cmoSampleClass": "Normal",
+      "oncoTreeCode": "CLL",
+      "collectionYear": "",
+      "tubeId": "",
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": "TNG41",
+          "barcodeIndex": "CGACTGGA",
+          "libraryIgoId": "MOCKREQUEST9_D_2_1_1_1",
+          "libraryVolume": 35.0,
+          "libraryConcentrationNgul": 33.5,
+          "captureConcentrationNm": "5.074626865671642",
+          "captureInputNg": "170.0",
+          "captureName": "Pool-MOCKREQUEST9_D-Tube7_1",
+          "runs": [
+            {
+              "runMode": "HiSeq High Output",
+              "runId": "RUNID_0123",
+              "flowCellId": "X5KL2KKAY",
+              "readLength": "",
+              "runDate": "2018-06-05",
+              "flowCellLanes": [
+                5
+              ],
+              "fastqs": [
+                "/FASTQ/Project_MOCKREQUEST9_D/Sample_01-0012345a_IGO_MOCKREQUEST9_D_2/01-0012345a_IGO_MOCKREQUEST9_D_2_S83_R2_001.fastq.gz",
+                "/FASTQ/Project_MOCKREQUEST9_D/Sample_01-0012345a_IGO_MOCKREQUEST9_D_2/01-0012345a_IGO_MOCKREQUEST9_D_2_S83_R1_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "cmoPatientId": "C-MP636AP",
+      "igoId": "MOCKREQUEST9_D_2",
+      "investigatorSampleId": "NORMAL_SAMPLE8_123",
+      "species": "Human",
+      "sex": "F",
+      "tumorOrNormal": "Normal",
+      "preservation": "Frozen",
+      "specimenType": "Blood",
+      "sampleOrigin": "Whole Blood",
+      "tissueLocation": "",
+      "baitSet": "GENESET101_BAITS",
+      "igoComplete": true,
+      "cmoSampleIdFields": {
+        "naToExtract": "",
+        "sampleType": "Whole Blood",
+        "normalizedPatientId": "MRN_REDACTED",
+        "recipe": "GENESET101_BAITS"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
+      }
+    }
+  ],
+  "pooledNormals": [
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FFPEPOOLEDNORMAL_IGO_GENESET101_TAGCTTGA/FFPEPOOLEDNORMAL_IGO_GENESET101_TAGCTTGA_S23_R1_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FFPEPOOLEDNORMAL_IGO_GENESET101_TAGCTTGA/FFPEPOOLEDNORMAL_IGO_GENESET101_TAGCTTGA_S23_R2_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG_S86_R1_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG_S86_R2_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG_S147_R1_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG_S147_R2_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG_S196_R1_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG_S196_R2_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT/MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT_S61_R1_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT/MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT_S61_R2_001.fastq.gz"
+  ],
+  "projectId": "MOCKREQUEST9"
+}

--- a/service/src/test/resources/data/incoming_requests/mocked_request9_duplicate_alt_ids.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request9_duplicate_alt_ids.json
@@ -1,6 +1,6 @@
 {
   "requestId": "MOCKREQUEST9_D",
-  "recipe": "GENESET101_BAITS",
+  "recipe": "HC_IMPACT",
   "projectManagerName": "Bar, Foo",
   "piEmail": "request8pi@mskcc.org",
   "labHeadName": "Foo Bar",
@@ -62,13 +62,13 @@
       "specimenType": "PDX",
       "sampleOrigin": "Tissue",
       "tissueLocation": "",
-      "baitSet": "GENESET101_BAITS",
+      "baitSet": "IMPACT505_BAITS",
       "igoComplete": true,
       "cmoSampleIdFields": {
         "naToExtract": "",
         "sampleType": "Tissue",
         "normalizedPatientId": "MRN_REDACTED",
-        "recipe": "GENESET101_BAITS"
+        "recipe": "HC_IMPACT"
       },
       "status": {
         "validationStatus": true,
@@ -122,13 +122,13 @@
       "specimenType": "Blood",
       "sampleOrigin": "Whole Blood",
       "tissueLocation": "",
-      "baitSet": "GENESET101_BAITS",
+      "baitSet": "IDT_Exome_v2_FP_BAITS",
       "igoComplete": true,
       "cmoSampleIdFields": {
         "naToExtract": "",
         "sampleType": "Whole Blood",
         "normalizedPatientId": "MRN_REDACTED",
-        "recipe": "GENESET101_BAITS"
+        "recipe": "WES_Human"
       },
       "status": {
         "validationStatus": true,

--- a/service/src/test/resources/data/incoming_requests/mocked_request9_duplicate_alt_ids.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request9_duplicate_alt_ids.json
@@ -16,7 +16,7 @@
   "bicAnalysis": false,
   "samples": [
     {
-      "altId": "AB9-ABC",
+      "altid": "AB9-ABC",
       "cmoSampleName": "",
       "sampleName": "XXX002_P3_12345_L1",
       "cmoSampleClass": "Primary",
@@ -76,7 +76,7 @@
       }
     },
     {
-      "altId": "AB9-ABC",
+      "altid": "AB9-ABC",
       "cmoSampleName": "",
       "sampleName": "01-0012345a",
       "cmoSampleClass": "Normal",

--- a/service/src/test/resources/data/mocked_request_data_details.txt
+++ b/service/src/test/resources/data/mocked_request_data_details.txt
@@ -30,3 +30,5 @@ mockRequest7SamplesMissingPids	incoming_requests/mocked_request7_samples_missing
 mockValidatedRequest7SamplesMissingPids	other_mocked_data/mocked_validated_request7_samples_missing_pids.json	Request JSON after going through validation and sanity checks in request filter. Based on 'mockRequest7SamplesMissingPids'.
 mockIncomingRequest8DupCmoLabels	incoming_requests/mocked_request8_duplicate_cmo_labels.json	Mock incoming request json with 2 normals with the same CMO labels.
 mockPublishedRequest8DupCmoLabels	published_requests/outgoing_mocked_request8_duplicate_cmo_labels.json	Mock request json with 2 normals with the same CMO labels.
+mockIncomingRequest9DupAltIds	incoming_requests/mocked_request9_duplicate_alt_ids.json	Mock incoming request json with 2 different samples with the same alt ID.
+mockPublishedRequest9DupAltIds	published_requests/outgoing_mocked_request9_duplicate_alt_ids.json	Mock request json with 2 different samples with the same alt ID.

--- a/service/src/test/resources/data/published_requests/outgoing_mocked_request9_duplicate_alt_ids.json
+++ b/service/src/test/resources/data/published_requests/outgoing_mocked_request9_duplicate_alt_ids.json
@@ -1,0 +1,216 @@
+{
+  "smileRequestId": "c2319627-787a-4a9e-a062-bc75330f1849",
+  "igoProjectId": "MOCKREQUEST9",
+  "igoRequestId": "MOCKREQUEST9_D",
+  "genePanel": "GENESET101_BAITS",
+  "projectManagerName": "Bar, Foo",
+  "piEmail": "request8pi@mskcc.org",
+  "labHeadName": "Foo Bar",
+  "labHeadEmail": "request1pi@mskcc.org",
+  "investigatorName": "John Smith",
+  "investigatorEmail": "smithj@mskcc.org",
+  "dataAnalystName": "Poin Dexter",
+  "dataAnalystEmail": "dexterp@mskcc.org",
+  "otherContactEmails": "dexterp@mskcc.org",
+  "dataAccessEmails": "",
+  "qcAccessEmails": "",
+  "strand": null,
+  "libraryType": null,
+  "isCmoRequest": true,
+  "bicAnalysis": false,
+  "status": {
+    "validationStatus": true,
+    "validationReport": "{}"
+  },
+  "requestJson": "{\"requestId\":\"MOCKREQUEST9_D\",\"projectId\":\"MOCKREQUEST1\",\"dataAccessEmails\":\"\",\"dataAnalystEmail\":\"dexterp@mskcc.org\",\"dataAnalystName\":\"Poin Dexter\",\"investigatorEmail\":\"smithj@mskcc.org\",\"investigatorName\":\"John Smith\",\"labHeadEmail\":\"request1pi@mskcc.org\",\"labHeadName\":\"Foo Bar\",\"libraryType\":null,\"otherContactEmails\":\"dexterp@mskcc.org\",\"piEmail\":\"request8pi@mskcc.org\",\"projectManagerName\":\"Bar, Foo\",\"qcAccessEmails\":\"\",\"recipe\":\"GENESET101_BAITS\",\"strand\":null,\"deliveryDate\":null,\"bicAnalysis\":false,\"isCmoRequest\":true,\"samples\":[{\"igoId\":\"MOCKREQUEST9_D_1\",\"cmoPatientId\":\"C-MP636AP\",\"cmoSampleName\":\"C-MP636AP-N001-d\",\"sampleName\":\"XXX002_P3_12345_L1\",\"baitSet\":\"GENESET101_BAITS\",\"cfDNA2dBarcode\":null,\"cmoInfoIgoId\":null,\"cmoSampleClass\":\"Primary\",\"collectionYear\":\"\",\"investigatorSampleId\":\"NORMAL_SAMPLE8_123\",\"oncoTreeCode\":\"CLL\",\"preservation\":\"Frozen\",\"sampleOrigin\":\"Tissue\",\"sex\":\"F\",\"species\":\"Human\",\"specimenType\":\"PDX\",\"tissueLocation\":\"\",\"tubeId\":\"\",\"tumorOrNormal\":\"Normal\",\"igoComplete\":true,\"qcReports\":[],\"libraries\":[{\"barcodeId\":\"IDT29\",\"barcodeIndex\":\"ATTGAGGA\",\"libraryIgoId\":\"MOCKREQUEST9_D_1_1_1_1\",\"libraryVolume\":35.0,\"libraryConcentrationNgul\":34.8,\"dnaInputNg\":null,\"captureConcentrationNm\":\"11.49425287356322\",\"captureInputNg\":\"400.0\",\"captureName\":\"Pool-MOCKREQUEST9_D-Tube7_1\",\"runs\":[{\"runMode\":\"HiSeq High Output\",\"runId\":\"RUNID_0123\",\"flowCellId\":\"X5KL2KKAY\",\"readLength\":\"\",\"runDate\":\"2018-06-05\",\"flowCellLanes\":[5],\"fastqs\":[\"/FASTQ/Project_MOCKREQUEST9_D/Sample_XXX002_P3_12345_L1_IGO_MOCKREQUEST9_D_1/XXX002_P3_12345_L1_IGO_MOCKREQUEST9_D_1_S82_R1_001.fastq.gz\",\"/FASTQ/Project_MOCKREQUEST9_D/Sample_XXX002_P3_12345_L1_IGO_MOCKREQUEST9_D_1/XXX002_P3_12345_L1_IGO_MOCKREQUEST9_D_1_S82_R2_001.fastq.gz\"]}]}],\"cmoSampleIdFields\":{\"naToExtract\":\"\",\"sampleType\":\"Tissue\",\"normalizedPatientId\":\"MRN_REDACTED\",\"recipe\":\"GENESET101_BAITS\"}},{\"igoId\":\"MOCKREQUEST9_D_2\",\"cmoPatientId\":\"C-MP636AP\",\"cmoSampleName\":\"C-MP636AP-N001-d\",\"sampleName\":\"01-0012345a\",\"baitSet\":\"GENESET101_BAITS\",\"cfDNA2dBarcode\":null,\"cmoInfoIgoId\":null,\"cmoSampleClass\":\"Normal\",\"collectionYear\":\"\",\"investigatorSampleId\":\"NORMAL_SAMPLE8_123\",\"oncoTreeCode\":\"CLL\",\"preservation\":\"Frozen\",\"sampleOrigin\":\"Whole Blood\",\"sex\":\"F\",\"species\":\"Human\",\"specimenType\":\"Blood\",\"tissueLocation\":\"\",\"tubeId\":\"\",\"tumorOrNormal\":\"Normal\",\"igoComplete\":true,\"qcReports\":[],\"libraries\":[{\"barcodeId\":\"TNG41\",\"barcodeIndex\":\"CGACTGGA\",\"libraryIgoId\":\"MOCKREQUEST9_D_2_1_1_1\",\"libraryVolume\":35.0,\"libraryConcentrationNgul\":33.5,\"dnaInputNg\":null,\"captureConcentrationNm\":\"5.074626865671642\",\"captureInputNg\":\"170.0\",\"captureName\":\"Pool-MOCKREQUEST9_D-Tube7_1\",\"runs\":[{\"runMode\":\"HiSeq High Output\",\"runId\":\"RUNID_0123\",\"flowCellId\":\"X5KL2KKAY\",\"readLength\":\"\",\"runDate\":\"2018-06-05\",\"flowCellLanes\":[5],\"fastqs\":[\"/FASTQ/Project_MOCKREQUEST9_D/Sample_01-0012345a_IGO_MOCKREQUEST9_D_2/01-0012345a_IGO_MOCKREQUEST9_D_2_S83_R2_001.fastq.gz\",\"/FASTQ/Project_MOCKREQUEST9_D/Sample_01-0012345a_IGO_MOCKREQUEST9_D_2/01-0012345a_IGO_MOCKREQUEST9_D_2_S83_R1_001.fastq.gz\"]}]}],\"cmoSampleIdFields\":{\"naToExtract\":\"\",\"sampleType\":\"Whole Blood\",\"normalizedPatientId\":\"MRN_REDACTED\",\"recipe\":\"GENESET101_BAITS\"}}],\"pooledNormals\":[\"/FASTQ/Project_POOLEDNORMALS/Sample_FFPEPOOLEDNORMAL_IGO_GENESET101_TAGCTTGA/FFPEPOOLEDNORMAL_IGO_GENESET101_TAGCTTGA_S23_R1_001.fastq.gz\",\"/FASTQ/Project_POOLEDNORMALS/Sample_FFPEPOOLEDNORMAL_IGO_GENESET101_TAGCTTGA/FFPEPOOLEDNORMAL_IGO_GENESET101_TAGCTTGA_S23_R2_001.fastq.gz\",\"/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG_S86_R1_001.fastq.gz\",\"/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG_S86_R2_001.fastq.gz\",\"/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG_S147_R1_001.fastq.gz\",\"/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG_S147_R2_001.fastq.gz\",\"/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG_S196_R1_001.fastq.gz\",\"/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG_S196_R2_001.fastq.gz\",\"/FASTQ/Project_POOLEDNORMALS/Sample_MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT/MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT_S61_R1_001.fastq.gz\",\"/FASTQ/Project_POOLEDNORMALS/Sample_MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT/MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT_S61_R2_001.fastq.gz\"]}",
+  "pooledNormals": [
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FFPEPOOLEDNORMAL_IGO_GENESET101_TAGCTTGA/FFPEPOOLEDNORMAL_IGO_GENESET101_TAGCTTGA_S23_R1_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FFPEPOOLEDNORMAL_IGO_GENESET101_TAGCTTGA/FFPEPOOLEDNORMAL_IGO_GENESET101_TAGCTTGA_S23_R2_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG_S86_R1_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG_S86_R2_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG_S147_R1_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG_S147_R2_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG_S196_R1_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG_S196_R2_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT/MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT_S61_R1_001.fastq.gz",
+    "/FASTQ/Project_POOLEDNORMALS/Sample_MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT/MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT_S61_R2_001.fastq.gz"
+  ],
+  "samples": [
+    {
+      "smileSampleId": "00a9d4df-dc88-4c6e-9535-3a0a80453a63",
+      "smilePatientId": "bac03a20-c092-4121-968f-21ebd3670323",
+      "primaryId": "MOCKREQUEST9_D_1",
+      "cmoPatientId": "C-MP636AP",
+      "cmoSampleName": "C-MP636AP-N001-d",
+      "sampleName": "XXX002_P3_12345_L1",
+      "cmoInfoIgoId": null,
+      "investigatorSampleId": "NORMAL_SAMPLE8_123",
+      "importDate": "2024-11-21",
+      "sampleType": "Primary",
+      "oncotreeCode": "CLL",
+      "collectionYear": "",
+      "tubeId": "",
+      "cfDNA2dBarcode": null,
+      "species": "Human",
+      "sex": "F",
+      "tumorOrNormal": "Normal",
+      "preservation": "Frozen",
+      "sampleClass": "PDX",
+      "sampleOrigin": "Tissue",
+      "tissueLocation": "",
+      "genePanel": "HC_IMPACT",
+      "baitSet": "IMPACT505_BAITS",
+      "datasource": "igo",
+      "igoComplete": true,
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
+      },
+      "cmoSampleIdFields": {
+        "naToExtract": "",
+        "sampleType": "Tissue",
+        "normalizedPatientId": "MRN_REDACTED",
+        "recipe": "HC_IMPACT"
+      },
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": "IDT29",
+          "barcodeIndex": "ATTGAGGA",
+          "libraryIgoId": "MOCKREQUEST9_D_1_1_1_1",
+          "libraryVolume": 35.0,
+          "libraryConcentrationNgul": 34.8,
+          "dnaInputNg": null,
+          "captureConcentrationNm": "11.49425287356322",
+          "captureInputNg": "400.0",
+          "captureName": "Pool-MOCKREQUEST9_D-Tube7_1",
+          "runs": [
+            {
+              "runMode": "HiSeq High Output",
+              "runId": "RUNID_0123",
+              "flowCellId": "X5KL2KKAY",
+              "readLength": "",
+              "runDate": "2018-06-05",
+              "flowCellLanes": [
+                5
+              ],
+              "fastqs": [
+                "/FASTQ/Project_MOCKREQUEST9_D/Sample_XXX002_P3_12345_L1_IGO_MOCKREQUEST9_D_1/XXX002_P3_12345_L1_IGO_MOCKREQUEST9_D_1_S82_R1_001.fastq.gz",
+                "/FASTQ/Project_MOCKREQUEST9_D/Sample_XXX002_P3_12345_L1_IGO_MOCKREQUEST9_D_1/XXX002_P3_12345_L1_IGO_MOCKREQUEST9_D_1_S82_R2_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "sampleAliases": [
+        {
+          "value": "NORMAL_SAMPLE8_123",
+          "namespace": "investigatorId"
+        },
+        {
+          "value": "MOCKREQUEST9_D_1",
+          "namespace": "igoId"
+        }
+      ],
+      "patientAliases": [
+        {
+          "value": "C-MP636AP",
+          "namespace": "cmoId"
+        }
+      ],
+      "additionalProperties": {
+        "igoRequestId": "MOCKREQUEST9_D",
+        "isCmoSample": "true",
+        "altId": "AB9-ABC"
+      }
+    },
+    {
+      "smileSampleId": "8c20b119-b2ba-477d-a332-9a3252b296b9",
+      "smilePatientId": "bac03a20-c092-4121-968f-21ebd3670323",
+      "primaryId": "MOCKREQUEST9_D_2",
+      "cmoPatientId": "C-MP636AP",
+      "cmoSampleName": "C-MP636AP-N001-d",
+      "sampleName": "01-0012345a",
+      "cmoInfoIgoId": null,
+      "investigatorSampleId": "NORMAL_SAMPLE8_123",
+      "importDate": "2024-11-21",
+      "sampleType": "Normal",
+      "oncotreeCode": "CLL",
+      "collectionYear": "",
+      "tubeId": "",
+      "cfDNA2dBarcode": null,
+      "species": "Human",
+      "sex": "F",
+      "tumorOrNormal": "Normal",
+      "preservation": "Frozen",
+      "sampleClass": "Blood",
+      "sampleOrigin": "Whole Blood",
+      "tissueLocation": "",
+      "genePanel": "WES_Human",
+      "baitSet": "IDT_Exome_v2_FP_BAITS",
+      "datasource": "igo",
+      "igoComplete": true,
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
+      },
+      "cmoSampleIdFields": {
+        "naToExtract": "",
+        "sampleType": "Whole Blood",
+        "normalizedPatientId": "MRN_REDACTED",
+        "recipe": "WES_Human"
+      },
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": "TNG41",
+          "barcodeIndex": "CGACTGGA",
+          "libraryIgoId": "MOCKREQUEST9_D_2_1_1_1",
+          "libraryVolume": 35.0,
+          "libraryConcentrationNgul": 33.5,
+          "dnaInputNg": null,
+          "captureConcentrationNm": "5.074626865671642",
+          "captureInputNg": "170.0",
+          "captureName": "Pool-MOCKREQUEST9_D-Tube7_1",
+          "runs": [
+            {
+              "runMode": "HiSeq High Output",
+              "runId": "RUNID_0123",
+              "flowCellId": "X5KL2KKAY",
+              "readLength": "",
+              "runDate": "2018-06-05",
+              "flowCellLanes": [
+                5
+              ],
+              "fastqs": [
+                "/FASTQ/Project_MOCKREQUEST9_D/Sample_01-0012345a_IGO_MOCKREQUEST9_D_2/01-0012345a_IGO_MOCKREQUEST9_D_2_S83_R2_001.fastq.gz",
+                "/FASTQ/Project_MOCKREQUEST9_D/Sample_01-0012345a_IGO_MOCKREQUEST9_D_2/01-0012345a_IGO_MOCKREQUEST9_D_2_S83_R1_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "sampleAliases": [
+        {
+          "value": "NORMAL_SAMPLE8_123",
+          "namespace": "investigatorId"
+        },
+        {
+          "value": "MOCKREQUEST9_D_2",
+          "namespace": "igoId"
+        }
+      ],
+      "patientAliases": [
+        {
+          "value": "C-MP636AP",
+          "namespace": "cmoId"
+        }
+      ],
+      "additionalProperties": {
+        "igoRequestId": "MOCKREQUEST9_D",
+        "isCmoSample": "true",
+        "altId": "AB9-ABC"
+      }
+    }
+  ]
+}

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -67,6 +67,7 @@ request_reply.patient_samples_topic=
 request_reply.crdb_mapping_topic=
 request_reply.cmo_label_generator_topic=
 request_reply.samples_by_cmo_label_topic=
+request_reply.samples_by_alt_id_topic=
 
 # cmo patient id correction topics
 smile.correct_cmoptid_topic=


### PR DESCRIPTION
# A descriptive title

Briefly describe changes proposed in this pull request:
- Add request-reply handler for fetching samples by alt ID

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Code checks:**
- [ ] Endpoints were tested to ensure their integrity.
- [ ] Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.
- [ ] Unit tests were updated in relation to updates to the mocked test data.

### II. Neo4j models and database schema checklist:
- [ ] Neo4j persistence models were changed.
- [ ] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]

### III. Message handlers checklist:
- [x] Changes in this PR affect the workflow of incoming messages.
- [x] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [x] Unit tests were added to ensure messages are handled as expected.

If no unit tests were updated or added, then please explain why: [insert details here]

Please describe how the workflow and messaging was tested/simulated:
Used the NATS CLI to send a request message to the alt ID topic along with a mock alt ID, and got back the mock sample containing the alt ID.

**Describe your testing environment:**

- NATS [local, local docker, dev server, production]
- Neo4j [local, local docker, dev server, production]
- SMILE Server [local, local docker, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, smile publisher tool, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### IV. Configuration and/or permissions checklist:
- [x] New topics were introduced.
- [x] The topics and appropriate permissions were updated in [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.

---
### Screenshots

---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)