### PR TITLE
Handle non-CMO request samples with no patient info

### DIFF
--- a/model/src/main/java/org/mskcc/smile/model/web/PublishedSmileSample.java
+++ b/model/src/main/java/org/mskcc/smile/model/web/PublishedSmileSample.java
@@ -72,8 +72,8 @@ public class PublishedSmileSample {
         this.cmoSampleName = latestSampleMetadata.getCmoSampleName();
         this.sampleName = latestSampleMetadata.getSampleName();
         this.sampleType = latestSampleMetadata.getSampleType();
+        // leaving this here in case this field ends up supporting non-cmo patient ids instead
         this.cmoPatientId = latestSampleMetadata.getCmoPatientId();
-        this.smilePatientId = smileSample.getPatient().getSmilePatientId();
         this.primaryId = latestSampleMetadata.getPrimaryId();
         this.investigatorSampleId = latestSampleMetadata.getInvestigatorSampleId();
         this.species = latestSampleMetadata.getSpecies();
@@ -96,9 +96,12 @@ public class PublishedSmileSample {
         this.libraries = latestSampleMetadata.getLibraries();
         this.sampleAliases = smileSample.getSampleAliases();
         this.cmoSampleIdFields = latestSampleMetadata.getCmoSampleIdFields();
-        this.patientAliases = smileSample.getPatient().getPatientAliases();
         this.additionalProperties = latestSampleMetadata.getAdditionalProperties();
         this.status = latestSampleMetadata.getStatus();
+        if (smileSample.getPatient() != null) {
+            this.smilePatientId = smileSample.getPatient().getSmilePatientId();
+            this.patientAliases = smileSample.getPatient().getPatientAliases();
+        }
     }
 
     public UUID getSmileSampleId() {

--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmilePatientRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmilePatientRepository.java
@@ -17,7 +17,7 @@ public interface SmilePatientRepository extends Neo4jRepository<SmilePatient, Lo
             + "RETURN p, ia, pa")
     SmilePatient findPatientByPatientSmileId(@Param("smilePatientId") UUID smileSampleId);
 
-    @Query("MATCH (s: Sample {smileSampleId: $smileSampleId})<-[hs:HAS_SAMPLE]-(p: Patient)"
+    @Query("OPTIONAL MATCH (s: Sample {smileSampleId: $smileSampleId})<-[hs:HAS_SAMPLE]-(p: Patient)"
             + "<-[ia:IS_ALIAS]-(pa: PatientAlias) "
             + "RETURN p, hs, ia, pa")
     SmilePatient findPatientBySampleSmileId(@Param("smileSampleId") UUID smileSampleId);

--- a/service/src/main/java/org/mskcc/smile/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/SampleServiceImpl.java
@@ -60,7 +60,9 @@ public class SampleServiceImpl implements SmileSampleService {
             sample) throws Exception {
         // sample to return
         SmileSample toReturn;
-        sample = fetchAndLoadPatientDetails(sample);
+        if (sample.getPatient() != null) {
+            sample = fetchAndLoadPatientDetails(sample);
+        }
 
         SmileSample existingSample =
                 sampleRepository.findSampleByPrimaryId(sample.getPrimarySampleAlias());
@@ -93,8 +95,9 @@ public class SampleServiceImpl implements SmileSampleService {
             }
 
             // determine whether a patient swap is required also
-            if (!sample.getPatient().getSmilePatientId().equals(
-                    existingSample.getPatient().getSmilePatientId())) {
+            if ((sample.getPatient() != null && existingSample.getPatient() != null)
+                    && !sample.getPatient().getSmilePatientId().equals(
+                            existingSample.getPatient().getSmilePatientId())) {
                 LOG.info("Updating sample-to-patient relationship and removing connection to patient: "
                         + existingSample.getPatient().getSmilePatientId());
                 sampleRepository.removeSamplePatientRelationship(existingSample.getSmileSampleId(),
@@ -115,6 +118,7 @@ public class SampleServiceImpl implements SmileSampleService {
                 }
                 existingSample.setPatient(patientToSwapTo);
             }
+
             sampleRepository.save(existingSample);
             toReturn = existingSample;
         }

--- a/service/src/main/java/org/mskcc/smile/service/util/SampleDataFactory.java
+++ b/service/src/main/java/org/mskcc/smile/service/util/SampleDataFactory.java
@@ -62,22 +62,28 @@ public class SampleDataFactory {
         }
         sampleMetadata.addAdditionalProperty("igoRequestId", requestId);
         if (isCmoRequest != null) {
-            sampleMetadata.addAdditionalProperty("isCmoSample", Boolean.TRUE.toString());
+            sampleMetadata.addAdditionalProperty("isCmoSample", String.valueOf(isCmoRequest));
         }
         sampleMetadata.setStatus(sampleStatus);
 
         SmileSample sample = new SmileSample();
         sample.addSampleMetadata(sampleMetadata);
         sample.setSampleCategory("research");
+        sample.setDatasource("igo");
         sample.setSampleClass(sampleMetadata.getTumorOrNormal());
         sample.addSampleAlias(new SampleAlias(sampleMetadata.getPrimaryId(), "igoId"));
-        sample.addSampleAlias(new SampleAlias(
-                sampleMetadata.getInvestigatorSampleId(), "investigatorId"));
-        sample.setDatasource("igo");
+        if (!StringUtils.isBlank(sampleMetadata.getInvestigatorSampleId())) {
+            sample.addSampleAlias(
+                    new SampleAlias(sampleMetadata.getInvestigatorSampleId(), "investigatorId"));
+        }
 
-        SmilePatient patient = new SmilePatient();
-        patient.addPatientAlias(new PatientAlias(sampleMetadata.getCmoPatientId(), "cmoId"));
-        sample.setPatient(patient);
+        // only create patient-sample relationship if the request is cmo and the patient id is non-empty
+        if (isCmoRequest != null && !StringUtils.isBlank(sampleMetadata.getCmoPatientId())) {
+            SmilePatient patient = new SmilePatient();
+            patient.addPatientAlias(new PatientAlias(sampleMetadata.getCmoPatientId(), "cmoId"));
+            sample.setPatient(patient);
+        }
+
         return sample;
     }
 
@@ -95,7 +101,7 @@ public class SampleDataFactory {
             IgoSampleManifest igoSampleManifest, Boolean isCmoRequest, Status sampleStatus)
             throws JsonProcessingException {
         SampleMetadata sampleMetadata = new SampleMetadata(igoSampleManifest);
-        return buildNewResearchSampleFromMetadata(requestId, sampleMetadata, null, sampleStatus);
+        return buildNewResearchSampleFromMetadata(requestId, sampleMetadata, isCmoRequest, sampleStatus);
     }
 
     /**

--- a/service/src/test/java/org/mskcc/smile/service/RequestServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/RequestServiceTest.java
@@ -220,7 +220,7 @@ public class RequestServiceTest {
 
         // requestAfterInitialUpdates will have this new version of metadata and will be
         // referenced again below
-        requestService.updateRequestMetadata(updatedRequest.getLatestRequestMetadata(), Boolean.TRUE);
+        requestService.updateRequestMetadata(updatedRequest.getLatestRequestMetadata(), Boolean.FALSE);
         Assertions.assertEquals(2, requestService.getRequestMetadataHistory(requestId).size());
 
         // now load instance of RequestMetadata ONLY from the mocked data object
@@ -307,7 +307,7 @@ public class RequestServiceTest {
 
         Boolean hasUpdates =
                 requestService.requestHasMetadataUpdates(origRequest.getLatestRequestMetadata(),
-                        updatedRequest.getLatestRequestMetadata(), Boolean.TRUE);
+                        updatedRequest.getLatestRequestMetadata(), Boolean.FALSE);
         Assertions.assertTrue(hasUpdates);
 
         requestService.saveRequest(updatedRequest);

--- a/service/src/test/java/org/mskcc/smile/service/SampleServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/SampleServiceTest.java
@@ -14,6 +14,8 @@ import org.mskcc.smile.model.SampleMetadata;
 import org.mskcc.smile.model.SmileRequest;
 import org.mskcc.smile.model.SmileSample;
 import org.mskcc.smile.model.dmp.DmpSampleMetadata;
+import org.mskcc.smile.model.web.PublishedSmileRequest;
+import org.mskcc.smile.model.web.PublishedSmileSample;
 import org.mskcc.smile.persistence.neo4j.CohortCompleteRepository;
 import org.mskcc.smile.persistence.neo4j.SmilePatientRepository;
 import org.mskcc.smile.persistence.neo4j.SmileRequestRepository;
@@ -176,6 +178,13 @@ public class SampleServiceTest {
                 sampleService.saveSmileSample(clinicalSample);
             }
         }
+
+        // save mock non-cmo request: 45102
+        MockJsonTestData nonCmoRequestData
+                = mockDataUtils.mockedRequestJsonDataMap.get("mockNonCmoRequest45102");
+        SmileRequest nonCmoRequest
+                = RequestDataFactory.buildNewLimsRequestFromJson(nonCmoRequestData.getJsonString());
+        requestService.saveRequest(nonCmoRequest);
     }
 
     /**
@@ -726,5 +735,22 @@ public class SampleServiceTest {
         String altId = "AB9-ABC";
         List<SmileSample> samplesMatchingAltIds = sampleService.getSamplesByAltId(altId);
         Assertions.assertEquals(2, samplesMatchingAltIds.size());
+    }
+
+    @Test
+    @Order(25)
+    public void testNonCmoRequest() throws Exception {
+        String nonCmoRequestId = "45102";
+        SmileRequest request = requestService.getSmileRequestById(nonCmoRequestId);
+        List<SmileSample> samples = request.getSmileSampleList();
+        Assertions.assertEquals(3, samples.size());
+        for (SmileSample s : samples) {
+            Assertions.assertNull(s.getPatient());
+        }
+
+        PublishedSmileRequest r = requestService.getPublishedSmileRequestById(nonCmoRequestId);
+        for (PublishedSmileSample s : r.getSamples()) {
+            Assertions.assertNull(s.getSmilePatientId());
+        }
     }
 }

--- a/service/src/test/resources/data/incoming_requests/mocked_non_cmo_request_45102.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_non_cmo_request_45102.json
@@ -1,0 +1,207 @@
+{
+  "requestId": "45102",
+  "requestName": "UserLibrary",
+  "recipe": "ChIPSeq",
+  "projectManagerName": "",
+  "piEmail": "",
+  "labHeadName": "John Smith",
+  "labHeadEmail": "smithj@address.org",
+  "investigatorName": "Llama Pajama",
+  "investigatorEmail": "llamap@address.org",
+  "dataAnalystName": "",
+  "dataAnalystEmail": "",
+  "otherContactEmails": "othercontact@mail.com",
+  "dataAccessEmails": "othecontact@mail.com",
+  "qcAccessEmails": "othercontact@mail.com",
+  "strand": null,
+  "libraryType": null,
+  "isCmoRequest": false,
+  "bicAnalysis": false,
+  "samples": [
+    {
+      "igoId": "45102_3",
+      "altid": "ABC-123",
+      "cmoSampleName": "",
+      "sampleName": "IP90",
+      "cmoSampleClass": "",
+      "cmoPatientId": "",
+      "investigatorSampleId": "IP90",
+      "oncoTreeCode": null,
+      "tumorOrNormal": "Normal",
+      "tissueLocation": "",
+      "specimenType": "",
+      "sampleOrigin": "",
+      "preservation": "",
+      "collectionYear": "",
+      "sex": "",
+      "species": "Mouse",
+      "tubeId": "",
+      "cfDNA2dBarcode": null,
+      "baitSet": "null",
+      "estimatedPurity": null,
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": null,
+          "barcodeIndex": null,
+          "libraryIgoId": null,
+          "libraryVolume": null,
+          "libraryConcentrationNgul": null,
+          "dnaInputNg": null,
+          "captureConcentrationNm": null,
+          "captureInputNg": null,
+          "captureName": null,
+          "runs": [
+            {
+              "runMode": null,
+              "runId": "INTRN_8989",
+              "flowCellId": "KLMDTRE5",
+              "readLength": null,
+              "runDate": "2023-10-04",
+              "flowCellLanes": [],
+              "fastqs": [
+                "/igo/delivery/FASTQ/Project_45102/Sample_IP90_IGO_45102_3/IP90_IGO_45102_3_S3_L001_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/Project_45102/Sample_IP90_IGO_45102_3/IP90_IGO_45102_3_S3_L001_R2_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "igoComplete": true,
+      "cmoSampleIdFields": {
+        "naToExtract": "",
+        "normalizedPatientId": "",
+        "sampleType": "DNA Library",
+        "recipe": "ChIPSeq"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
+      }
+    },
+    {
+      "igoId": "45102_1",
+      "altid": "AC9-G4R",
+      "cmoSampleName": "",
+      "sampleName": "PL92",
+      "cmoSampleClass": "",
+      "cmoPatientId": "",
+      "investigatorSampleId": "PL92",
+      "oncoTreeCode": null,
+      "tumorOrNormal": "Normal",
+      "tissueLocation": "",
+      "specimenType": "",
+      "sampleOrigin": "",
+      "preservation": "",
+      "collectionYear": "",
+      "sex": "",
+      "species": "Mouse",
+      "tubeId": "",
+      "cfDNA2dBarcode": null,
+      "baitSet": "null",
+      "estimatedPurity": null,
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": null,
+          "barcodeIndex": null,
+          "libraryIgoId": null,
+          "libraryVolume": null,
+          "libraryConcentrationNgul": null,
+          "dnaInputNg": null,
+          "captureConcentrationNm": null,
+          "captureInputNg": null,
+          "captureName": null,
+          "runs": [
+            {
+              "runMode": null,
+              "runId": "INTRN_8989",
+              "flowCellId": "KLMDTRE5",
+              "readLength": null,
+              "runDate": "2023-10-04",
+              "flowCellLanes": [],
+              "fastqs": [
+                "/igo/delivery/FASTQ/Project_45102/Sample_PL92_IGO_45102_1/PL92_IGO_45102_1_S1_L001_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/Project_45102/Sample_PL92_IGO_45102_1/PL92_IGO_45102_1_S1_L001_R2_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "igoComplete": true,
+      "cmoSampleIdFields": {
+        "naToExtract": "",
+        "normalizedPatientId": "",
+        "sampleType": "DNA Library",
+        "recipe": "ChIPSeq"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
+      }
+    },
+    {
+      "igoId": "45102_2",
+      "altid": "ALP-PP2",
+      "cmoSampleName": "",
+      "sampleName": "TN34",
+      "cmoSampleClass": "",
+      "cmoPatientId": "",
+      "investigatorSampleId": "TN34",
+      "oncoTreeCode": null,
+      "tumorOrNormal": "Normal",
+      "tissueLocation": "",
+      "specimenType": "",
+      "sampleOrigin": "",
+      "preservation": "",
+      "collectionYear": "",
+      "sex": "",
+      "species": "Mouse",
+      "tubeId": "",
+      "cfDNA2dBarcode": null,
+      "baitSet": "null",
+      "estimatedPurity": null,
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": null,
+          "barcodeIndex": null,
+          "libraryIgoId": null,
+          "libraryVolume": null,
+          "libraryConcentrationNgul": null,
+          "dnaInputNg": null,
+          "captureConcentrationNm": null,
+          "captureInputNg": null,
+          "captureName": null,
+          "runs": [
+            {
+              "runMode": null,
+              "runId": "INTRN_8989",
+              "flowCellId": "KLMDTRE5",
+              "readLength": null,
+              "runDate": "2023-10-04",
+              "flowCellLanes": [],
+              "fastqs": [
+                "/igo/delivery/FASTQ/Project_45102/Sample_TN34_IGO_45102_2/TN34_IGO_45102_2_S2_L001_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/Project_45102/Sample_TN34_IGO_45102_2/TN34_IGO_45102_2_S2_L001_R2_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "igoComplete": true,
+      "cmoSampleIdFields": {
+        "naToExtract": "",
+        "normalizedPatientId": "",
+        "sampleType": "DNA Library",
+        "recipe": "ChIPSeq"
+      },
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
+      }
+    }
+  ],
+  "pooledNormals": null,
+  "projectId": "45102"
+}

--- a/service/src/test/resources/data/incoming_requests/mocked_request1_updated_complete_tumor_normal.json
+++ b/service/src/test/resources/data/incoming_requests/mocked_request1_updated_complete_tumor_normal.json
@@ -1,19 +1,19 @@
 {
   "requestId": "MOCKREQUEST1_B",
-  "recipe": "GENESET101",
+  "recipe": "UPDATED_GENESET",
   "projectManagerName": "Bar, Foo",
-  "piEmail": "request1pi@mskcc.org",
+  "piEmail": "new_request1pi@mskcc.org",
   "labHeadName": "Foo Bar",
-  "labHeadEmail": "request1pi@mskcc.org",
+  "labHeadEmail": "UPDATED_request1pi@mskcc.org",
   "investigatorName": "John Smith",
   "investigatorEmail": "NEWINVESTIGATOREMAIL@mskcc.org",
   "dataAnalystName": "Poin Dexter",
   "dataAnalystEmail": "dexterp@mskcc.org",
   "otherContactEmails": "dexterp@mskcc.org",
-  "dataAccessEmails": "",
+  "dataAccessEmails": "someaccesemaillist",
   "qcAccessEmails": "invalid-igo-update",
-  "isCmoRequest": false,
-  "bicAnalysis": false,
+  "isCmoRequest": true,
+  "bicAnalysis": true,
   "samples": [
     {
       "cmoSampleName": "C-MP789JR-X001-d",
@@ -258,11 +258,7 @@
     "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG_S86_R1_001.fastq.gz",
     "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_AMBIGUOUS_TTAGGCTG_S86_R2_001.fastq.gz",
     "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG_S147_R1_001.fastq.gz",
-    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG_S147_R2_001.fastq.gz",
-    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG_S196_R1_001.fastq.gz",
-    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_GENESET101_TTAGGCTG_S196_R2_001.fastq.gz",
-    "/FASTQ/Project_POOLEDNORMALS/Sample_MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT/MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT_S61_R1_001.fastq.gz",
-    "/FASTQ/Project_POOLEDNORMALS/Sample_MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT/MOUSEPOOLEDNORMAL_IGO_AMBIGUOUS_GGCGTCAT_S61_R2_001.fastq.gz"
+    "/FASTQ/Project_POOLEDNORMALS/Sample_FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG/FROZENPOOLEDNORMAL_IGO_HEMESET_v1_TTAGGCTG_S147_R2_001.fastq.gz"
   ],
   "projectId": "MOCKREQUEST1"
 }

--- a/service/src/test/resources/data/mocked_request_data_details.txt
+++ b/service/src/test/resources/data/mocked_request_data_details.txt
@@ -32,3 +32,5 @@ mockIncomingRequest8DupCmoLabels	incoming_requests/mocked_request8_duplicate_cmo
 mockPublishedRequest8DupCmoLabels	published_requests/outgoing_mocked_request8_duplicate_cmo_labels.json	Mock request json with 2 normals with the same CMO labels.
 mockIncomingRequest9DupAltIds	incoming_requests/mocked_request9_duplicate_alt_ids.json	Mock incoming request json with 2 different samples with the same alt ID.
 mockPublishedRequest9DupAltIds	published_requests/outgoing_mocked_request9_duplicate_alt_ids.json	Mock request json with 2 different samples with the same alt ID.
+mockNonCmoRequest45102	incoming_requests/mocked_non_cmo_request_45102.json	Mock non-CMO request json.
+mockPublishedNonCmoRequest45102	published_requests/outgoing_mocked_non_cmo_request_45102.json	Mock published non-CMO request.

--- a/service/src/test/resources/data/published_requests/outgoing_mocked_non_cmo_request_45102.json
+++ b/service/src/test/resources/data/published_requests/outgoing_mocked_non_cmo_request_45102.json
@@ -1,0 +1,272 @@
+{
+  "smileRequestId": "9921fa52-c37e-4223-8f28-483eb58ef19d",
+  "igoProjectId": "45102",
+  "igoRequestId": "45102",
+  "genePanel": "ChIPSeq",
+  "projectManagerName": "",
+  "piEmail": "",
+  "labHeadName": "John Smith",
+  "labHeadEmail": "smithj@address.org",
+  "investigatorName": "Llama Pajama",
+  "investigatorEmail": "llamap@address.org",
+  "dataAnalystName": "",
+  "dataAnalystEmail": "",
+  "otherContactEmails": "othercontact@mail.com",
+  "dataAccessEmails": "othecontact@mail.com",
+  "qcAccessEmails": "othercontact@mail.com",
+  "strand": null,
+  "libraryType": null,
+  "isCmoRequest": false,
+  "bicAnalysis": false,
+  "status": {
+    "validationStatus": true,
+    "validationReport": "{}"
+  },
+  "requestJson": "{\"requestId\":\"45102\",\"projectId\":\"45102\",\"dataAccessEmails\":\"othecontact@mail.com\",\"dataAnalystEmail\":\"\",\"dataAnalystName\":\"\",\"investigatorEmail\":\"llamap@address.org\",\"investigatorName\":\"Llama Pajama\",\"labHeadEmail\":\"smithj@address.org\",\"labHeadName\":\"John Smith\",\"libraryType\":null,\"otherContactEmails\":\"othercontact@mail.com\",\"piEmail\":\"\",\"projectManagerName\":\"\",\"qcAccessEmails\":\"othercontact@mail.com\",\"recipe\":\"ChIPSeq\",\"strand\":null,\"deliveryDate\":null,\"bicAnalysis\":false,\"isCmoRequest\":false,\"samples\":[{\"igoId\":\"45102_3\",\"cmoPatientId\":\"\",\"cmoSampleName\":\"\",\"sampleName\":\"IP90\",\"altid\":\"ABC-123\",\"baitSet\":\"null\",\"cfDNA2dBarcode\":null,\"cmoInfoIgoId\":null,\"cmoSampleClass\":\"\",\"collectionYear\":\"\",\"investigatorSampleId\":\"IP90\",\"oncoTreeCode\":null,\"preservation\":\"\",\"sampleOrigin\":\"\",\"sex\":\"\",\"species\":\"Mouse\",\"specimenType\":\"\",\"tissueLocation\":\"\",\"tubeId\":\"\",\"tumorOrNormal\":\"Normal\",\"igoComplete\":true,\"qcReports\":[],\"libraries\":[{\"barcodeId\":null,\"barcodeIndex\":null,\"libraryIgoId\":null,\"libraryVolume\":null,\"libraryConcentrationNgul\":null,\"dnaInputNg\":null,\"captureConcentrationNm\":null,\"captureInputNg\":null,\"captureName\":null,\"runs\":[{\"runMode\":null,\"runId\":\"INTRN_8989\",\"flowCellId\":\"KLMDTRE5\",\"readLength\":null,\"runDate\":\"2023-10-04\",\"flowCellLanes\":[],\"fastqs\":[\"/igo/delivery/FASTQ/Project_45102/Sample_IP90_IGO_45102_3/IP90_IGO_45102_3_S3_L001_R1_001.fastq.gz\",\"/igo/delivery/FASTQ/Project_45102/Sample_IP90_IGO_45102_3/IP90_IGO_45102_3_S3_L001_R2_001.fastq.gz\"]}]}],\"cmoSampleIdFields\":{\"naToExtract\":\"\",\"normalizedPatientId\":\"\",\"sampleType\":\"DNA Library\",\"recipe\":\"ChIPSeq\"}},{\"igoId\":\"45102_1\",\"cmoPatientId\":\"\",\"cmoSampleName\":\"\",\"sampleName\":\"PL92\",\"altid\":\"AC9-G4R\",\"baitSet\":\"null\",\"cfDNA2dBarcode\":null,\"cmoInfoIgoId\":null,\"cmoSampleClass\":\"\",\"collectionYear\":\"\",\"investigatorSampleId\":\"PL92\",\"oncoTreeCode\":null,\"preservation\":\"\",\"sampleOrigin\":\"\",\"sex\":\"\",\"species\":\"Mouse\",\"specimenType\":\"\",\"tissueLocation\":\"\",\"tubeId\":\"\",\"tumorOrNormal\":\"Normal\",\"igoComplete\":true,\"qcReports\":[],\"libraries\":[{\"barcodeId\":null,\"barcodeIndex\":null,\"libraryIgoId\":null,\"libraryVolume\":null,\"libraryConcentrationNgul\":null,\"dnaInputNg\":null,\"captureConcentrationNm\":null,\"captureInputNg\":null,\"captureName\":null,\"runs\":[{\"runMode\":null,\"runId\":\"INTRN_8989\",\"flowCellId\":\"KLMDTRE5\",\"readLength\":null,\"runDate\":\"2023-10-04\",\"flowCellLanes\":[],\"fastqs\":[\"/igo/delivery/FASTQ/Project_45102/Sample_PL92_IGO_45102_1/PL92_IGO_45102_1_S1_L001_R1_001.fastq.gz\",\"/igo/delivery/FASTQ/Project_45102/Sample_PL92_IGO_45102_1/PL92_IGO_45102_1_S1_L001_R2_001.fastq.gz\"]}]}],\"cmoSampleIdFields\":{\"naToExtract\":\"\",\"normalizedPatientId\":\"\",\"sampleType\":\"DNA Library\",\"recipe\":\"ChIPSeq\"}},{\"igoId\":\"45102_2\",\"cmoPatientId\":\"\",\"cmoSampleName\":\"\",\"sampleName\":\"TN34\",\"altid\":\"ALP-PP2\",\"baitSet\":\"null\",\"cfDNA2dBarcode\":null,\"cmoInfoIgoId\":null,\"cmoSampleClass\":\"\",\"collectionYear\":\"\",\"investigatorSampleId\":\"TN34\",\"oncoTreeCode\":null,\"preservation\":\"\",\"sampleOrigin\":\"\",\"sex\":\"\",\"species\":\"Mouse\",\"specimenType\":\"\",\"tissueLocation\":\"\",\"tubeId\":\"\",\"tumorOrNormal\":\"Normal\",\"igoComplete\":true,\"qcReports\":[],\"libraries\":[{\"barcodeId\":null,\"barcodeIndex\":null,\"libraryIgoId\":null,\"libraryVolume\":null,\"libraryConcentrationNgul\":null,\"dnaInputNg\":null,\"captureConcentrationNm\":null,\"captureInputNg\":null,\"captureName\":null,\"runs\":[{\"runMode\":null,\"runId\":\"INTRN_8989\",\"flowCellId\":\"KLMDTRE5\",\"readLength\":null,\"runDate\":\"2023-10-04\",\"flowCellLanes\":[],\"fastqs\":[\"/igo/delivery/FASTQ/Project_45102/Sample_TN34_IGO_45102_2/TN34_IGO_45102_2_S2_L001_R1_001.fastq.gz\",\"/igo/delivery/FASTQ/Project_45102/Sample_TN34_IGO_45102_2/TN34_IGO_45102_2_S2_L001_R2_001.fastq.gz\"]}]}],\"cmoSampleIdFields\":{\"naToExtract\":\"\",\"normalizedPatientId\":\"\",\"sampleType\":\"DNA Library\",\"recipe\":\"ChIPSeq\"}}],\"pooledNormals\":[]}",
+  "pooledNormals": [],
+  "samples": [
+    {
+      "smileSampleId": "8b6a09da-6eb1-4e6b-891b-1a75b0307969",
+      "smilePatientId": null,
+      "primaryId": "45102_1",
+      "cmoPatientId": "",
+      "cmoSampleName": "",
+      "sampleName": "PL92",
+      "cmoInfoIgoId": null,
+      "investigatorSampleId": "PL92",
+      "importDate": "2025-02-07",
+      "sampleType": "",
+      "oncotreeCode": null,
+      "collectionYear": "",
+      "tubeId": "",
+      "cfDNA2dBarcode": null,
+      "species": "Mouse",
+      "sex": "",
+      "tumorOrNormal": "Normal",
+      "preservation": "",
+      "sampleClass": "",
+      "sampleOrigin": "",
+      "tissueLocation": "",
+      "genePanel": "ChIPSeq",
+      "baitSet": "null",
+      "datasource": "igo",
+      "igoComplete": true,
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
+      },
+      "cmoSampleIdFields": {
+        "naToExtract": "",
+        "normalizedPatientId": "",
+        "sampleType": "DNA Library",
+        "recipe": "ChIPSeq"
+      },
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": null,
+          "barcodeIndex": null,
+          "libraryIgoId": null,
+          "libraryVolume": null,
+          "libraryConcentrationNgul": null,
+          "dnaInputNg": null,
+          "captureConcentrationNm": null,
+          "captureInputNg": null,
+          "captureName": null,
+          "runs": [
+            {
+              "runMode": null,
+              "runId": "INTRN_8989",
+              "flowCellId": "KLMDTRE5",
+              "readLength": null,
+              "runDate": "2023-10-04",
+              "flowCellLanes": [],
+              "fastqs": [
+                "/igo/delivery/FASTQ/Project_45102/Sample_PL92_IGO_45102_1/PL92_IGO_45102_1_S1_L001_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/Project_45102/Sample_PL92_IGO_45102_1/PL92_IGO_45102_1_S1_L001_R2_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "sampleAliases": [
+        {
+          "value": "PL92",
+          "namespace": "investigatorId"
+        },
+        {
+          "value": "45102_1",
+          "namespace": "igoId"
+        }
+      ],
+      "patientAliases": null,
+      "additionalProperties": {
+        "isCmoSample": "false",
+        "altId": "AC9-G4R",
+        "igoRequestId": "45102"
+      }
+    },
+    {
+      "smileSampleId": "f2b4ec52-32d1-4ffa-b5af-4149848aa373",
+      "smilePatientId": null,
+      "primaryId": "45102_3",
+      "cmoPatientId": "",
+      "cmoSampleName": "",
+      "sampleName": "IP90",
+      "cmoInfoIgoId": null,
+      "investigatorSampleId": "IP90",
+      "importDate": "2025-02-07",
+      "sampleType": "",
+      "oncotreeCode": null,
+      "collectionYear": "",
+      "tubeId": "",
+      "cfDNA2dBarcode": null,
+      "species": "Mouse",
+      "sex": "",
+      "tumorOrNormal": "Normal",
+      "preservation": "",
+      "sampleClass": "",
+      "sampleOrigin": "",
+      "tissueLocation": "",
+      "genePanel": "ChIPSeq",
+      "baitSet": "null",
+      "datasource": "igo",
+      "igoComplete": true,
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
+      },
+      "cmoSampleIdFields": {
+        "naToExtract": "",
+        "normalizedPatientId": "",
+        "sampleType": "DNA Library",
+        "recipe": "ChIPSeq"
+      },
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": null,
+          "barcodeIndex": null,
+          "libraryIgoId": null,
+          "libraryVolume": null,
+          "libraryConcentrationNgul": null,
+          "dnaInputNg": null,
+          "captureConcentrationNm": null,
+          "captureInputNg": null,
+          "captureName": null,
+          "runs": [
+            {
+              "runMode": null,
+              "runId": "INTRN_8989",
+              "flowCellId": "KLMDTRE5",
+              "readLength": null,
+              "runDate": "2023-10-04",
+              "flowCellLanes": [],
+              "fastqs": [
+                "/igo/delivery/FASTQ/Project_45102/Sample_IP90_IGO_45102_3/IP90_IGO_45102_3_S3_L001_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/Project_45102/Sample_IP90_IGO_45102_3/IP90_IGO_45102_3_S3_L001_R2_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "sampleAliases": [
+        {
+          "value": "45102_3",
+          "namespace": "igoId"
+        },
+        {
+          "value": "IP90",
+          "namespace": "investigatorId"
+        }
+      ],
+      "patientAliases": null,
+      "additionalProperties": {
+        "isCmoSample": "false",
+        "altId": "ABC-123",
+        "igoRequestId": "45102"
+      }
+    },
+    {
+      "smileSampleId": "ea0fd7f6-0597-4dc3-89ea-4644eca61cd8",
+      "smilePatientId": null,
+      "primaryId": "45102_2",
+      "cmoPatientId": "",
+      "cmoSampleName": "",
+      "sampleName": "TN34",
+      "cmoInfoIgoId": null,
+      "investigatorSampleId": "TN34",
+      "importDate": "2025-02-07",
+      "sampleType": "",
+      "oncotreeCode": null,
+      "collectionYear": "",
+      "tubeId": "",
+      "cfDNA2dBarcode": null,
+      "species": "Mouse",
+      "sex": "",
+      "tumorOrNormal": "Normal",
+      "preservation": "",
+      "sampleClass": "",
+      "sampleOrigin": "",
+      "tissueLocation": "",
+      "genePanel": "ChIPSeq",
+      "baitSet": "null",
+      "datasource": "igo",
+      "igoComplete": true,
+      "status": {
+        "validationStatus": true,
+        "validationReport": "{}"
+      },
+      "cmoSampleIdFields": {
+        "naToExtract": "",
+        "normalizedPatientId": "",
+        "sampleType": "DNA Library",
+        "recipe": "ChIPSeq"
+      },
+      "qcReports": [],
+      "libraries": [
+        {
+          "barcodeId": null,
+          "barcodeIndex": null,
+          "libraryIgoId": null,
+          "libraryVolume": null,
+          "libraryConcentrationNgul": null,
+          "dnaInputNg": null,
+          "captureConcentrationNm": null,
+          "captureInputNg": null,
+          "captureName": null,
+          "runs": [
+            {
+              "runMode": null,
+              "runId": "INTRN_8989",
+              "flowCellId": "KLMDTRE5",
+              "readLength": null,
+              "runDate": "2023-10-04",
+              "flowCellLanes": [],
+              "fastqs": [
+                "/igo/delivery/FASTQ/Project_45102/Sample_TN34_IGO_45102_2/TN34_IGO_45102_2_S2_L001_R1_001.fastq.gz",
+                "/igo/delivery/FASTQ/Project_45102/Sample_TN34_IGO_45102_2/TN34_IGO_45102_2_S2_L001_R2_001.fastq.gz"
+              ]
+            }
+          ]
+        }
+      ],
+      "sampleAliases": [
+        {
+          "value": "45102_2",
+          "namespace": "igoId"
+        },
+        {
+          "value": "TN34",
+          "namespace": "investigatorId"
+        }
+      ],
+      "patientAliases": null,
+      "additionalProperties": {
+        "isCmoSample": "false",
+        "altId": "ALP-PP2",
+        "igoRequestId": "45102"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Handle non-CMO request samples with no patient info

Briefly describe changes proposed in this pull request:
- Supports import and persistence of non-cmo samples with no patient information more gracefully. The web service doesn't throw an internal server error for these requests anymore. 
- Added mocked data and unit tests for this case.  
