### PR TITLE
Update persistence layer calls to return distinct results always

### DIFF
--- a/model/src/main/java/org/mskcc/smile/model/SmileSample.java
+++ b/model/src/main/java/org/mskcc/smile/model/SmileSample.java
@@ -133,6 +133,13 @@ public class SmileSample implements Serializable {
                 return s.getValue();
             }
         }
+
+        // check latest metadata for primary id if not found in sample aliases
+        // which is possible when limited sample data is returned by a sample query
+        if (latestMetadata != null) {
+            return latestMetadata.getPrimaryId();
+        }
+
         return null;
     }
 

--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/CohortCompleteRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/CohortCompleteRepository.java
@@ -15,15 +15,15 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CohortCompleteRepository extends Neo4jRepository<Cohort, Long> {
     @Query("MATCH (c: Cohort {cohortId: $cohortId})-[hcc:HAS_COHORT_COMPLETE]->(cc: CohortComplete) "
-            + "RETURN c, hcc, cc")
+            + "RETURN DISTINCT c, hcc, cc")
     Cohort findCohortByCohortId(@Param("cohortId") String cohortId);
 
     @Query("MATCH (c: Cohort {cohortId: $cohortId})-[:HAS_COHORT_COMPLETE]->(cc: CohortComplete) "
-            + "RETURN cc ORDER BY cc.date DESC LIMIT 1")
+            + "RETURN DISTINCT cc ORDER BY cc.date DESC LIMIT 1")
     CohortComplete findLatestCohortCompleteEventByCohortId(@Param("cohortId") String cohortId);
 
     @Query("MATCH (c: Cohort)-[:HAS_COHORT_SAMPLE]->(s: Sample)-[:HAS_METADATA]->(sm: SampleMetadata "
-            + "{primaryId: $primaryId}) RETURN c")
+            + "{primaryId: $primaryId}) RETURN DISTINCT c")
     List<Cohort> findCohortsBySamplePrimaryId(@Param("primaryId") String primaryId);
 
     @Query("MATCH (s: Sample)-[:HAS_METADATA]->(sm: SampleMetadata {primaryId: $primaryId}) "

--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmilePatientRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmilePatientRepository.java
@@ -14,25 +14,25 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SmilePatientRepository extends Neo4jRepository<SmilePatient, Long> {
     @Query("MATCH (p: Patient {smilePatientId: $smilePatientId})<-[ia:IS_ALIAS]-(pa: PatientAlias) "
-            + "RETURN p, ia, pa")
+            + "RETURN DISTINCT p, ia, pa")
     SmilePatient findPatientByPatientSmileId(@Param("smilePatientId") UUID smileSampleId);
 
     @Query("OPTIONAL MATCH (s: Sample {smileSampleId: $smileSampleId})<-[hs:HAS_SAMPLE]-(p: Patient)"
             + "<-[ia:IS_ALIAS]-(pa: PatientAlias) "
-            + "RETURN p, hs, ia, pa")
+            + "RETURN DISTINCT p, hs, ia, pa")
     SmilePatient findPatientBySampleSmileId(@Param("smileSampleId") UUID smileSampleId);
 
     @Query("MATCH (p: Patient)<-[:IS_ALIAS]-(pa: PatientAlias) "
             + "WHERE pa.namespace = 'cmoId' AND pa.value = $cmoPatientId "
             + "MATCH (p)<-[ipa:IS_ALIAS]-(pa2: PatientAlias) "
-            + "RETURN p, ipa, pa2")
+            + "RETURN DISTINCT p, ipa, pa2")
     SmilePatient findPatientByCmoPatientId(
             @Param("cmoPatientId") String cmoPatientId);
 
     @Query("MATCH (p: Patient)<-[:IS_ALIAS]-(pa: PatientAlias {value: $oldCmoId, namespace: 'cmoId'}) "
             + "SET pa.value = $newCmoId WITH p "
             + "MATCH (p)<-[ipa:IS_ALIAS]-(pa2: PatientAlias) "
-            + "RETURN p, ipa, pa2")
+            + "RETURN DISTINCT p, ipa, pa2")
     SmilePatient updateCmoPatientIdInPatientNode(@Param("oldCmoId") String oldCmoId,
             @Param("newCmoId") String newCmoId);
 

--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileRequestRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileRequestRepository.java
@@ -20,12 +20,12 @@ public interface SmileRequestRepository extends Neo4jRepository<SmileRequest, Lo
 
     @Query("MATCH (s: Sample {smileSampleId: $smileSample.smileSampleId}) "
             + "MATCH (s)<-[:HAS_SAMPLE]-(r: Request) "
-            + "RETURN r")
+            + "RETURN DISTINCT r")
     SmileRequest findRequestByResearchSample(@Param("smileSample") SmileSample smileSample);
 
     @Query("MATCH (r: Request {igoRequestId: $reqId}) "
             + "MATCH (r)-[:HAS_METADATA]->(rm: RequestMetadata)-[hs:HAS_STATUS]->(rs: Status) "
-            + "RETURN rm, hs, rs")
+            + "RETURN DISTINCT rm, hs, rs")
     List<RequestMetadata> findRequestMetadataHistoryByRequestId(@Param("reqId") String reqId);
 
     @Query("MATCH (r: Request)-[:HAS_METADATA]->(rm: RequestMetadata) "

--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileSampleRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileSampleRepository.java
@@ -23,7 +23,7 @@ public interface SmileSampleRepository extends Neo4jRepository<SmileSample, UUID
             + "OPTIONAL MATCH (t)-[hbe:HAS_EVENT]->(bc: BamComplete) "
             + "OPTIONAL MATCH (t)-[hqe:HAS_EVENT]->(qc: QcComplete) "
             + "OPTIONAL MATCH (t)-[hme:HAS_EVENT]->(mc: MafComplete) "
-            + "RETURN s, hsm, sm, hss, ss, isa, sa, ht, t, hbe, bc, hqe, qc, hme, mc")
+            + "RETURN DISTINCT s, hsm, sm, hss, ss, isa, sa, ht, t, hbe, bc, hqe, qc, hme, mc")
     SmileSample findSampleBySampleSmileId(@Param("smileSampleId") UUID smileSampleId);
 
     @Query("MATCH (s: Sample)-[:HAS_METADATA]->(sm: SampleMetadata {primaryId: $primaryId}) "
@@ -41,38 +41,38 @@ public interface SmileSampleRepository extends Neo4jRepository<SmileSample, UUID
 
     @Query("MATCH (s: Sample {smileSampleId: $smileSampleId})-[:HAS_METADATA]->(sm: SampleMetadata) "
             + "OPTIONAL MATCH (sm)-[hs:HAS_STATUS]->(ss: Status) "
-            + "RETURN sm, hs, ss")
+            + "RETURN DISTINCT sm, hs, ss")
     List<SampleMetadata> findAllSampleMetadataListBySampleId(@Param("smileSampleId") UUID smileSampleId);
 
     @Query("MATCH (s: Sample {smileSampleId: $smileSample.smileSampleId})"
             + "MATCH (s)<-[:HAS_SAMPLE]-(p: Patient)"
             + "MATCH (n: Sample)<-[:HAS_SAMPLE]-(p) "
             + "WHERE toLower(n.sampleClass) = 'normal'"
-            + "RETURN n")
+            + "RETURN DISTINCT n")
     List<SmileSample> findMatchedNormalsByResearchSample(
             @Param("smileSample") SmileSample smileSample);
 
     @Query("MATCH (r: Request {igoRequestId: $reqId})-[:HAS_SAMPLE]->"
             + "(s: Sample) "
-            + "RETURN s")
+            + "RETURN DISTINCT s")
     List<SmileSample> findResearchSamplesByRequest(@Param("reqId") String reqId);
 
     @Query("MATCH (r: Request {igoRequestId: $reqId}) "
         + "MATCH(r)-[:HAS_SAMPLE]->(s: Sample) "
         + "MATCH (s)<-[:IS_ALIAS]-(sa: SampleAlias {namespace: 'igoId', value: $igoId}) "
-        + "RETURN s")
+        + "RETURN DISTINCT s")
     SmileSample findResearchSampleByRequestAndIgoId(@Param("reqId") String reqId,
             @Param("igoId") String igoId);
 
     @Query("MATCH (pa: PatientAlias {namespace: 'cmoId', value: $cmoPatientId})-[:IS_ALIAS]->"
             + "(p: Patient)-[:HAS_SAMPLE]->(s: Sample) "
-            + "RETURN s")
+            + "RETURN DISTINCT s")
     List<SmileSample> findAllSamplesByCmoPatientId(
             @Param("cmoPatientId") String cmoPatientId);
 
     @Query("MATCH (pa: PatientAlias {namespace: 'cmoId', value: $cmoPatientId})-[:IS_ALIAS]->"
             + "(p: Patient)-[:HAS_SAMPLE]->(s: Sample {sampleCategory: $sampleCategory}) "
-            + "RETURN s")
+            + "RETURN DISTINCT s")
     List<SmileSample> findAllSamplesByCategoryAndCmoPatientId(
             @Param("cmoPatientId") String cmoPatientId, @Param("sampleCategory") String sampleCategory);
 
@@ -80,7 +80,7 @@ public interface SmileSampleRepository extends Neo4jRepository<SmileSample, UUID
             + "-[:IS_ALIAS]->(s: Sample)"
             + "-[:HAS_METADATA]->(sm: SampleMetadata) "
             + "OPTIONAL MATCH (sm)-[hs:HAS_STATUS]->(ss: Status) "
-            + "RETURN sm, hs, ss")
+            + "RETURN DISTINCT sm, hs, ss")
     List<SampleMetadata> findSampleMetadataHistoryByNamespaceValue(
             @Param("namespace") String namespace, @Param("value") String value);
 
@@ -96,7 +96,7 @@ public interface SmileSampleRepository extends Neo4jRepository<SmileSample, UUID
 
     @Query("MATCH (s: Sample {smileSampleId: $smileSampleId})-[:HAS_METADATA]->(sm: SampleMetadata) "
             + "OPTIONAL MATCH (sm)-[hs:HAS_STATUS]->(ss: Status) "
-            + "RETURN sm, hs, ss ORDER BY sm.importDate DESC LIMIT 1")
+            + "RETURN DISTINCT sm, hs, ss ORDER BY sm.importDate DESC LIMIT 1")
     SampleMetadata findLatestSampleMetadataBySmileId(@Param("smileSampleId") UUID smileSampleId);
 
     @Query("MATCH (sm:SampleMetadata)<-[:HAS_METADATA]-(s:Sample)<-[:IS_ALIAS]-(sa:SampleAlias) "
@@ -105,7 +105,7 @@ public interface SmileSampleRepository extends Neo4jRepository<SmileSample, UUID
             + "OR s.smileSampleId = $inputId "
             + "OR sm.cmoSampleName = $inputId "
             + "OR sm.investigatorSampleId = $inputId "
-            + "RETURN s")
+            + "RETURN DISTINCT s")
     SmileSample findSampleByInputId(@Param("inputId") String inputId);
 
     @Query("MATCH (s: Sample {smileSampleId: $smileSampleId}) "
@@ -122,16 +122,16 @@ public interface SmileSampleRepository extends Neo4jRepository<SmileSample, UUID
 
     @Query("MATCH (s: Sample {smileSampleId: $smileSampleId}) "
             + "SET s.revisable = $revisable "
-            + "RETURN s")
+            + "RETURN DISTINCT s")
     SmileSample updateRevisableBySampleId(@Param("smileSampleId") UUID smileSampleId,
             @Param("revisable") Boolean revisable);
 
     @Query("MATCH (c: Cohort {cohortId: $cohortId})-[:HAS_COHORT_SAMPLE]->"
             + "(s: Sample) "
-            + "RETURN s")
+            + "RETURN DISTINCT s")
     List<SmileSample> findSamplesByCohortId(@Param("cohortId") String cohortId);
 
     @Query("MATCH (sm:SampleMetadata {primaryId: $primaryId})"
-            + "RETURN sm.cmoSampleName ORDER BY sm.importDate DESC LIMIT 1")
+            + "RETURN DISTINCT sm.cmoSampleName ORDER BY sm.importDate DESC LIMIT 1")
     String findCmoSampleNameByPrimaryId(@Param("primaryId") String primaryId);
 }

--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/TempoRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/TempoRepository.java
@@ -19,47 +19,47 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TempoRepository extends Neo4jRepository<Tempo, UUID> {
     @Query("MATCH (s: Sample {smileSampleId: $smileSampleId})-[:HAS_TEMPO]->(t: Tempo) "
-            + "RETURN t")
+            + "RETURN DISTINCT t")
     Tempo findTempoBySmileSampleId(@Param("smileSampleId") UUID smileSampleId);
 
     @Query("MATCH (s: Sample)-[:HAS_METADATA]->(sm: SampleMetadata {primaryId: $primaryId}) "
-            + "MATCH (s)-[:HAS_TEMPO]->(t:Tempo) RETURN t")
+            + "MATCH (s)-[:HAS_TEMPO]->(t:Tempo) RETURN DISTINCT t")
     Tempo findTempoBySamplePrimaryId(@Param("primaryId") String primaryId);
 
     @Query("MATCH (t: Tempo) WHERE t.smileTempoId = $smileTempoId MATCH (t)-[:HAS_EVENT]->(bc: BamComplete) "
-            + "RETURN bc")
+            + "RETURN DISTINCT bc")
     List<BamComplete> findBamCompleteEventsByTempoId(@Param("smileTempoId") UUID smileTempoId);
 
     @Query("MATCH (t: Tempo) WHERE t.smileTempoId = $smileTempoId MATCH (t)-[:HAS_EVENT]->(qc: QcComplete) "
-            + "RETURN qc")
+            + "RETURN DISTINCT qc")
     List<QcComplete> findQcCompleteEventsByTempoId(@Param("smileTempoId") UUID smileTempoId);
     @Query("MATCH (t: Tempo) WHERE t.smileTempoId = $smileTempoId MATCH (t)-[:HAS_EVENT]->(mc: MafComplete) "
-            + "RETURN mc")
+            + "RETURN DISTINCT mc")
     List<MafComplete> findMafCompleteEventsByTempoId(@Param("smileTempoId") UUID smileTempoId);
 
     @Query("MATCH (t:Tempo) WHERE t.smileTempoId = $smileTempoId MATCH (t)-[:HAS_EVENT]->(bc: BamComplete) "
-            + "RETURN bc ORDER BY bc.date DESC LIMIT 1")
+            + "RETURN DISTINCT bc ORDER BY bc.date DESC LIMIT 1")
     BamComplete findLatestBamCompleteEventByTempoId(@Param("smileTempoId") UUID smileTempoId);
 
     @Query("MATCH (t:Tempo) WHERE t.smileTempoId = $smileTempoId MATCH (t)-[:HAS_EVENT]->(mc: MafComplete) "
-            + "RETURN mc ORDER BY mc.date DESC LIMIT 1")
+            + "RETURN DISTINCT mc ORDER BY mc.date DESC LIMIT 1")
     MafComplete findLatestMafCompleteEventByTempoId(@Param("smileTempoId") UUID smileTempoId);
 
     @Query("MATCH (t:Tempo) WHERE t.smileTempoId = $smileTempoId MATCH (t)-[:HAS_EVENT]->(qc: QcComplete) "
-            + "RETURN qc ORDER BY qc.date DESC LIMIT 1")
+            + "RETURN DISTINCT qc ORDER BY qc.date DESC LIMIT 1")
     QcComplete findLatestQcCompleteEventByTempoId(@Param("smileTempoId") UUID smileTempoId);
 
     @Query("MATCH (s: Sample)-[:HAS_METADATA]->(sm: SampleMetadata {primaryId: $primaryId}) "
             + "MERGE (s)-[ht:HAS_TEMPO]->(t: Tempo) WITH s,t "
             + "MERGE (t)-[he:HAS_EVENT]->(bc: BamComplete {date: $bcEvent.date, "
-            + "status: $bcEvent.status}) WITH s,t,bc RETURN t")
+            + "status: $bcEvent.status}) WITH s,t,bc RETURN DISTINCT t")
     Tempo mergeBamCompleteEventBySamplePrimaryId(@Param("primaryId") String primaryId,
             @Param("bcEvent") BamComplete bcEvent);
 
     @Query("MATCH (s: Sample)-[:HAS_METADATA]->(sm: SampleMetadata {primaryId: $primaryId}) "
             + "MERGE (s)-[ht:HAS_TEMPO]->(t: Tempo) WITH s,t "
             + "MERGE (t)-[he:HAS_EVENT]->(qc: QcComplete {date: $qcEvent.date, result: $qcEvent.result, "
-            + "reason: $qcEvent.reason, status: $qcEvent.status}) WITH s,t,qc RETURN t")
+            + "reason: $qcEvent.reason, status: $qcEvent.status}) WITH s,t,qc RETURN DISTINCT t")
     Tempo mergeQcCompleteEventBySamplePrimaryId(@Param("primaryId") String primaryId,
             @Param("qcEvent") QcComplete qcEvent);
 
@@ -67,7 +67,7 @@ public interface TempoRepository extends Neo4jRepository<Tempo, UUID> {
             + "MERGE (s)-[ht:HAS_TEMPO]->(t: Tempo) WITH s,t "
             + "MERGE (t)-[he:HAS_EVENT]->(mc: MafComplete {date: $mcEvent.date, "
             + "normalPrimaryId: $mcEvent.normalPrimaryId, status: $mcEvent.status}) "
-            + "WITH s,t,mc RETURN t")
+            + "WITH s,t,mc RETURN DISTINCT t")
     Tempo mergeMafCompleteEventBySamplePrimaryId(@Param("primaryId") String primaryId,
             @Param("mcEvent") MafComplete mcEvent);
 
@@ -80,6 +80,6 @@ public interface TempoRepository extends Neo4jRepository<Tempo, UUID> {
 
     @Query("MATCH (cc:CohortComplete)<-[:HAS_COHORT_COMPLETE]-(c:Cohort)-[:HAS_COHORT_SAMPLE]"
             + "->(s:Sample)-[:HAS_METADATA]->(sm: SampleMetadata {primaryId: $primaryId}) "
-            + "RETURN cc.date ORDER BY cc.date ASC LIMIT 1")
+            + "RETURN DISTINCT cc.date ORDER BY cc.date ASC LIMIT 1")
     String findInitialPipelineRunDateBySamplePrimaryId(@Param("primaryId") String primaryId);
 }

--- a/service/src/main/java/org/mskcc/smile/service/impl/TempoServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/TempoServiceImpl.java
@@ -156,7 +156,7 @@ public class TempoServiceImpl implements TempoService {
     private LocalDate getInitialPipelineRunDateBySamplePrimaryId(String primaryId) throws Exception {
         String dateString = tempoRepository.findInitialPipelineRunDateBySamplePrimaryId(primaryId);
         if (StringUtils.isEmpty(dateString)) {
-            LOG.warn("No Initial Pipeline Run Date found for sample with Primary ID: " + primaryId);
+            LOG.debug("No Initial Pipeline Run Date found for sample with Primary ID: " + primaryId);
             return null;
         }
         DateTimeFormatter runDateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");


### PR DESCRIPTION
# A descriptive title

Briefly describe changes proposed in this pull request:
- a
- b 

---
## Troubleshooting

Fix # (see https://help.github.com/en/articles/closing-issues-using-keywords)

**Expected behavior**

**Actual behavior**

**Logs, error output, or stacktrace**

**Steps to reproduce the behavior**

**Tasks**

Include specific tasks in the order they need to be done in. Include links to specific lines of code where the task should happen at. 

- [ ] task 1
- [ ] task 2
- [ ] task 3

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Code checks:**
- [ ] Endpoints were tested to ensure their integrity.
- [ ] Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.
- [ ] Unit tests were updated in relation to updates to the mocked test data.

### II. Neo4j models and database schema checklist:
- [ ] Neo4j persistence models were changed.
- [ ] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]

### III. Message handlers checklist:
- [ ] Changes in this PR affect the workflow of incoming messages.
- [ ] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [ ] Unit tests were added to ensure messages are handled as expected.

If no unit tests were updated or added, then please explain why: [insert details here]

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, local docker, dev server, production]
- Neo4j [local, local docker, dev server, production]
- SMILE Server [local, local docker, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, smile publisher tool, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### IV. Configuration and/or permissions checklist:
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.

---
### Screenshots

---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
