### PR TITLE
Monitor embargo status changes for TEMPO-CBio pipeline (#1457)

### DIFF
--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileSampleRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileSampleRepository.java
@@ -134,4 +134,9 @@ public interface SmileSampleRepository extends Neo4jRepository<SmileSample, UUID
     @Query("MATCH (sm:SampleMetadata {primaryId: $primaryId})"
             + "RETURN sm ORDER BY sm.importDate DESC LIMIT 1")
     SampleMetadata findLatestSampleMetadataByPrimaryId(@Param("primaryId") String primaryId);
+
+    @Query("MATCH (t:Tempo)<-[:HAS_TEMPO]-(s:Sample)-[:HAS_METADATA]->(sm:SampleMetadata) "
+            + "WHERE t.smileTempoId IN $smileTempoIds "
+            + "RETURN DISTINCT sm.primaryId")
+    List<String> findSamplePrimaryIdsBySmileTempoIds(@Param("smileTempoIds") List<UUID> smileTempoIds);
 }

--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/TempoRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/TempoRepository.java
@@ -1,6 +1,7 @@
 package org.mskcc.smile.persistence.neo4j;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.mskcc.smile.model.tempo.BamComplete;
 import org.mskcc.smile.model.tempo.MafComplete;
@@ -82,4 +83,53 @@ public interface TempoRepository extends Neo4jRepository<Tempo, UUID> {
             + "->(s:Sample)-[:HAS_METADATA]->(sm: SampleMetadata {primaryId: $primaryId}) "
             + "RETURN cc.date ORDER BY cc.date ASC LIMIT 1")
     String findInitialPipelineRunDateBySamplePrimaryId(@Param("primaryId") String primaryId);
+
+    @Query("MATCH (t:Tempo {accessLevel: 'MSK Embargo'}) "
+            + "WHERE date(t.embargoDate) < date() "
+            + "RETURN t.smileTempoId")
+    List<UUID> findTempoIdsNoLongerEmbargoed();
+
+    @Query("MATCH (sm: SampleMetadata)<-[:HAS_METADATA]-(s: Sample)-[:HAS_TEMPO]->(t:Tempo) "
+            + "WHERE sm.primaryId IN $samplePrimaryIds SET t.accessLevel = $accessLevel")
+    void updateTempoAccessLevelBySamplePrimaryIds(@Param("samplePrimaryIds") List<String> samplePrimaryIds,
+            @Param("accessLevel") String accessLevel);
+
+    @Query("MATCH (s:Sample)-[:HAS_TEMPO]->(t:Tempo) "
+            + "WITH s, t, COLLECT { "
+            + "MATCH (s)-[:HAS_METADATA]->(sm:SampleMetadata) "
+            + "RETURN sm ORDER BY sm.importDate DESC LIMIT 1 "
+            + "} AS latestSm "
+            + "WITH s, t, latestSm[0] as latestSm "
+            + "MATCH (p:Patient)-[:HAS_SAMPLE]->(s) "
+            + "OPTIONAL MATCH (p)<-[:IS_ALIAS]-(pa:PatientAlias{namespace: 'cmoId'}) "
+            + "WITH s, t, latestSm, p, pa AS cmoIdAlias "
+            + "OPTIONAL MATCH (p)<-[:IS_ALIAS]-(pa:PatientAlias{namespace: 'dmpId'}) "
+            + "WITH s,t,latestSm,p,cmoIdAlias, pa as dmpIdAlias, "
+            + "CASE WHEN latestSm.investigatorSampleId =~ '^P-\\d{7}-.*-WES$' "
+            + "THEN true ELSE false END as recapture "
+            + "WITH "
+            + "latestSm.primaryId AS primaryId, "
+            + "latestSm.cmoSampleName AS cmoSampleName, "
+            + "t.accessLevel AS accessLevel, "
+            + "t.custodianInformation AS custodianInformation, "
+            + "latestSm.baitSet AS baitSet, "
+            + "latestSm.genePanel AS genePanel, "
+            + "latestSm.oncotreeCode AS oncotreeCode, "
+            + "latestSm.cmoPatientId AS cmoPatientId, "
+            + "dmpIdAlias.value AS dmpPatientId, "
+            + "recapture AS recapture "
+            + "WITH ({ "
+            + "primaryId: primaryId, "
+            + "cmoSampleName: cmoSampleName, "
+            + "accessLevel: accessLevel, "
+            + "custodianInformation: custodianInformation, "
+            + "baitSet: baitSet, "
+            + "genePanel: genePanel, "
+            + "oncotreeCode: oncotreeCode, "
+            + "cmoPatientId: cmoPatientId, "
+            + "dmpPatientId: dmpPatientId, "
+            + "recapture: recapture }) AS result "
+            + "WHERE result.primaryId = $primaryId "
+            + "RETURN result")
+    Map<String, Object> findTempoSampleDataBySamplePrimaryId(@Param("primaryId") String primaryId);
 }

--- a/server/src/main/java/org/mskcc/smile/SmileApp.java
+++ b/server/src/main/java/org/mskcc/smile/SmileApp.java
@@ -22,6 +22,7 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.stereotype.Controller;
 
 @EntityScan(basePackages = "org.mskcc.smile.model")
@@ -31,6 +32,7 @@ import org.springframework.stereotype.Controller;
         "org.mskcc.smile.commons.*", "org.mskcc.smile.*"})
 @Controller
 @EnableCaching
+@EnableScheduling
 public class SmileApp implements CommandLineRunner {
     private static final Log LOG = LogFactory.getLog(SmileApp.class);
 

--- a/service/src/main/java/org/mskcc/smile/service/SmileSampleService.java
+++ b/service/src/main/java/org/mskcc/smile/service/SmileSampleService.java
@@ -38,5 +38,5 @@ public interface SmileSampleService {
     List<SmileSample> getSamplesByCmoSampleName(String cmoSampleName) throws Exception;
     List<SmileSample> getSamplesByAltId(String altId) throws Exception;
     SampleMetadata getLatestSampleMetadataByPrimaryId(String primaryId) throws Exception;
-    Boolean sampleIsRecapture(String investigatorSampleId) throws Exception;
+    List<String> getSamplePrimaryIdsBySmileTempoIds(List<UUID> smileTempoIds) throws Exception;
 }

--- a/service/src/main/java/org/mskcc/smile/service/TempoMessageHandlingService.java
+++ b/service/src/main/java/org/mskcc/smile/service/TempoMessageHandlingService.java
@@ -1,5 +1,6 @@
 package org.mskcc.smile.service;
 
+import java.util.List;
 import java.util.Map;
 import org.mskcc.cmo.messaging.Gateway;
 import org.mskcc.smile.model.tempo.BamComplete;
@@ -19,5 +20,6 @@ public interface TempoMessageHandlingService {
     void mafCompleteHandler(Map.Entry<String, MafComplete> mcEvent) throws Exception;
     void cohortCompleteHandler(CohortCompleteJson ccEvent) throws Exception;
     void sampleBillingHandler(SampleBillingJson billing) throws Exception;
+    void tempoEmbargoStatusHandler(List<String> samplePrimaryIds) throws Exception;
     void shutdown() throws Exception;
 }

--- a/service/src/main/java/org/mskcc/smile/service/TempoService.java
+++ b/service/src/main/java/org/mskcc/smile/service/TempoService.java
@@ -1,5 +1,8 @@
 package org.mskcc.smile.service;
 
+import java.util.List;
+import java.util.UUID;
+import org.mskcc.smile.commons.generated.Smile.TempoSample;
 import org.mskcc.smile.model.SmileSample;
 import org.mskcc.smile.model.tempo.BamComplete;
 import org.mskcc.smile.model.tempo.MafComplete;
@@ -20,4 +23,7 @@ public interface TempoService {
     Tempo mergeMafCompleteEventBySamplePrimaryId(String primaryId, MafComplete mafComplete) throws Exception;
     Tempo initAndSaveDefaultTempoData(String primaryId) throws Exception;
     void updateSampleBilling(SampleBillingJson billing) throws Exception;
+    List<UUID> getTempoIdsNoLongerEmbargoed() throws Exception;
+    void updateTempoAccessLevel(List<String> samplePrimaryIds, String accessLevel) throws Exception;
+    TempoSample getTempoSampleDataBySamplePrimaryId(String primaryId) throws Exception;
 }

--- a/service/src/main/java/org/mskcc/smile/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/SampleServiceImpl.java
@@ -32,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class SampleServiceImpl implements SmileSampleService {
     private static final Pattern DMP_PATIENT_ID = Pattern.compile("P-\\d*");
-    private static final Pattern RECAPTURE_INVESTIGATOR_SAMPLE_ID = Pattern.compile("^P-\\d{6}-.*-WES$");
+
     @Autowired
     private JsonComparator jsonComparator;
 
@@ -531,10 +531,7 @@ public class SampleServiceImpl implements SmileSampleService {
     }
 
     @Override
-    public Boolean sampleIsRecapture(String investigatorSampleId) {
-        if (StringUtils.isBlank(investigatorSampleId)) {
-            return Boolean.FALSE;
-        }
-        return RECAPTURE_INVESTIGATOR_SAMPLE_ID.matcher(investigatorSampleId).matches();
+    public List<String> getSamplePrimaryIdsBySmileTempoIds(List<UUID> smileTempoIds) throws Exception {
+        return sampleRepository.findSamplePrimaryIdsBySmileTempoIds(smileTempoIds);
     }
 }

--- a/service/src/main/java/org/mskcc/smile/service/impl/TempoServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/TempoServiceImpl.java
@@ -3,10 +3,14 @@ package org.mskcc.smile.service.impl;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.logging.log4j.util.Strings;
+import org.mskcc.smile.commons.generated.Smile.TempoSample;
 import org.mskcc.smile.model.SmileRequest;
 import org.mskcc.smile.model.SmileSample;
 import org.mskcc.smile.model.tempo.BamComplete;
@@ -41,15 +45,20 @@ public class TempoServiceImpl implements TempoService {
 
     private static final Log LOG = LogFactory.getLog(TempoServiceImpl.class);
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
-    private static final String ACCESS_LEVEL_EMBARGO = "MSK Embargo";
-    private static final String ACCESS_LEVEL_PUBLIC = "MSK Public";
     private static final int EMBARGO_PERIOD_MONTHS = 18;
+
+    public static final String ACCESS_LEVEL_EMBARGO = "MSK Embargo";
+    public static final String ACCESS_LEVEL_PUBLIC = "MSK Public";
 
 
     @Override
     @Transactional(rollbackFor = {Exception.class})
     public Tempo saveTempoData(Tempo tempo) throws Exception {
         SmileSample sample = tempo.getSmileSample();
+        Tempo existingTempo = tempoRepository.findTempoBySmileSampleId(sample.getSmileSampleId());
+        if (existingTempo != null) {
+            tempo.setSmileTempoId(existingTempo.getSmileTempoId());
+        }
 
         // if sample is a normal sample then no need to set values for custodian
         // information or access level. Normal samples do not require this info.
@@ -184,9 +193,6 @@ public class TempoServiceImpl implements TempoService {
                         ? ACCESS_LEVEL_PUBLIC : ACCESS_LEVEL_EMBARGO);
             }
         } else {
-            // explicitly set dates to empty strings if no initial pipeline run date is found
-            tempo.setInitialPipelineRunDate("");
-            tempo.setEmbargoDate("");
             if (!sampleIsMarkedAsPublic(accessLevel)) {
                 tempo.setAccessLevel(ACCESS_LEVEL_EMBARGO);
             }
@@ -208,4 +214,47 @@ public class TempoServiceImpl implements TempoService {
         return accessLevelLower.contains("public") || accessLevelLower.contains("publish")
             || accessLevelLower.contains("pmid");
     }
+
+    @Override
+    public List<UUID> getTempoIdsNoLongerEmbargoed() throws Exception {
+        return tempoRepository.findTempoIdsNoLongerEmbargoed();
+    }
+
+    @Override
+    @Transactional(rollbackFor = {Exception.class})
+    public void updateTempoAccessLevel(List<String> samplePrimaryIds, String accessLevel) throws Exception {
+        tempoRepository.updateTempoAccessLevelBySamplePrimaryIds(samplePrimaryIds, accessLevel);
+    }
+
+    @Override
+    public TempoSample getTempoSampleDataBySamplePrimaryId(String primaryId) throws Exception {
+        Map<String, Object> tempoSampleMap = tempoRepository.findTempoSampleDataBySamplePrimaryId(primaryId);
+        if (tempoSampleMap == null) {
+            return null;
+        }
+
+        // build tempo sample object
+        TempoSample tempoSample = TempoSample.newBuilder()
+            .setPrimaryId(primaryId)
+            .setCmoSampleName(
+                    StringUtils.defaultIfBlank((String) tempoSampleMap.get("cmoSampleName"), ""))
+            .setAccessLevel(
+                    StringUtils.defaultIfBlank((String) tempoSampleMap.get("accessLevel"), ""))
+            .setCustodianInformation(
+                    StringUtils.defaultIfBlank((String) tempoSampleMap.get("custodianInformation"), ""))
+            .setBaitSet(
+                    StringUtils.defaultIfBlank((String) tempoSampleMap.get("baitSet"), ""))
+            .setGenePanel(
+                    StringUtils.defaultIfBlank((String) tempoSampleMap.get("genePanel"), ""))
+            .setOncotreeCode(
+                    StringUtils.defaultIfBlank((String) tempoSampleMap.get("oncotreeCode"), ""))
+            .setCmoPatientId(
+                    StringUtils.defaultIfBlank((String) tempoSampleMap.get("cmoPatientId"), ""))
+            .setDmpPatientId(
+                    StringUtils.defaultIfBlank((String) tempoSampleMap.get("dmpPatientId"), ""))
+            .setRecapture((Boolean) tempoSampleMap.get("recapture"))
+            .build();
+        return tempoSample;
+    }
+
 }

--- a/service/src/main/java/org/mskcc/smile/service/util/TempoEmbargoStatusScheduler.java
+++ b/service/src/main/java/org/mskcc/smile/service/util/TempoEmbargoStatusScheduler.java
@@ -1,0 +1,52 @@
+package org.mskcc.smile.service.util;
+
+import java.util.List;
+import java.util.UUID;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.mskcc.smile.service.SmileSampleService;
+import org.mskcc.smile.service.TempoMessageHandlingService;
+import org.mskcc.smile.service.TempoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ *
+ * @author qu8n
+ */
+@Component
+public class TempoEmbargoStatusScheduler {
+    @Autowired
+    private TempoService tempoService;
+
+    @Autowired
+    private SmileSampleService sampleService;
+
+    @Autowired
+    private TempoMessageHandlingService tempoMessageHandlingService;
+
+    private static final Log LOG = LogFactory.getLog(TempoEmbargoStatusScheduler.class);
+
+    /**
+     * Checks for changes in TEMPO embargo status.
+     */
+    @Scheduled(cron = "0 0 0 * * ?") // every day at midnight
+    public void checkEmbargoStatusChangesDaily() {
+        try {
+            LOG.info("Checking for Tempo records that are no longer embargoed...");
+            List<UUID> tempoIdsNoLongerEmbargoed = tempoService.getTempoIdsNoLongerEmbargoed();
+            if (!tempoIdsNoLongerEmbargoed.isEmpty()) {
+                // add to tempo messaging queue
+                LOG.info(tempoIdsNoLongerEmbargoed.size() + " TEMPO nodes no longer embargoed.");
+                List<String> samplePrimaryIds = sampleService.getSamplePrimaryIdsBySmileTempoIds(
+                        tempoIdsNoLongerEmbargoed);
+
+                LOG.info("Updating embargo status for " + samplePrimaryIds.size() + " samples");
+                tempoMessageHandlingService.tempoEmbargoStatusHandler(samplePrimaryIds);
+            }
+        } catch (Exception e) {
+            LOG.error("Error running the daily job checkEmbargoStatusChangesDaily: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -80,3 +80,5 @@ tempo.wes_maf_complete_topic=
 tempo.wes_cohort_complete_topic=
 tempo.sample_billing_topic=
 tempo.release_samples_topic=
+tempo.update_samples_embargo_topic=
+


### PR DESCRIPTION
# Monitor embargo status changes for TEMPO-CBio pipeline

Briefly describe changes proposed in this pull request:
- Added scheduler to check for changes to embargo status daily
- Added message handler to the tempo message service that publishes samples with updates to embargo status/access level to the TEMPO-cBioPortal pipeline.
- Added a corresponding unit test for finding TEMPO data that is no longer under embargo

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Code checks:**
- [ ] ~~Endpoints were tested to ensure their integrity.~~
- [ ] ~~Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.~~
- [ ] ~~Unit tests were updated in relation to updates to the mocked test data.~~

### II. Neo4j models and database schema checklist: n/a
```
- [ ] Neo4j persistence models were changed.
- [ ] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]
```
### III. Message handlers checklist:
- [x] Changes in this PR affect the workflow of incoming messages.
- [x] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [x] Unit tests were added to ensure messages are handled as expected.

If no unit tests were updated or added, then please explain why: [insert details here]

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, local docker, dev server, production]
- Neo4j [local, local docker, dev server, production]
- SMILE Server [local, local docker, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, smile publisher tool, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### IV. Configuration and/or permissions checklist: 
- [x] New topics were introduced.
- [x] The topics and appropriate permissions were updated in [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] ~~If applicable, a new account was set up and the account credentials and keys are checked into [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).~~
- [ ] ~~Account credentials and keys were shared with the appropriate parties.~~

---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
