### PR TITLE
Allow updates to sample init pipeline run date where applicable

### DIFF
--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/TempoRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/TempoRepository.java
@@ -82,7 +82,7 @@ public interface TempoRepository extends Neo4jRepository<Tempo, UUID> {
     @Query("MATCH (cc:CohortComplete)<-[:HAS_COHORT_COMPLETE]-(c:Cohort)-[:HAS_COHORT_SAMPLE]"
             + "->(s:Sample)-[:HAS_METADATA]->(sm: SampleMetadata {primaryId: $primaryId}) "
             + "RETURN cc.date ORDER BY cc.date ASC LIMIT 1")
-    String findInitialPipelineRunDateBySamplePrimaryId(@Param("primaryId") String primaryId);
+    String findEarliestCohortDeliveryDateBySamplePrimaryId(@Param("primaryId") String primaryId);
 
     @Query("MATCH (t:Tempo {accessLevel: 'MSK Embargo'}) "
             + "WHERE date(t.embargoDate) < date() "
@@ -132,4 +132,12 @@ public interface TempoRepository extends Neo4jRepository<Tempo, UUID> {
             + "WHERE result.primaryId = $primaryId "
             + "RETURN result")
     Map<String, Object> findTempoSampleDataBySamplePrimaryId(@Param("primaryId") String primaryId);
+
+    @Query("MATCH (t: Tempo{smileTempoId: $smileTempoId}) "
+            + "SET t.initialPipelineRunDate = $initialPipelineRunDate, "
+            + "t.embargoDate = $embargoDate, t.accessLevel = $accessLevel")
+    void updateTempoData(@Param("smileTempoId") UUID smileTempoId,
+            @Param("initialPipelineRunDate") String initialPipelineRunDate,
+            @Param("embargoDate") String embargoDate,
+            @Param("accessLevel") String accessLevel);
 }

--- a/service/src/main/java/org/mskcc/smile/service/TempoService.java
+++ b/service/src/main/java/org/mskcc/smile/service/TempoService.java
@@ -26,4 +26,5 @@ public interface TempoService {
     List<UUID> getTempoIdsNoLongerEmbargoed() throws Exception;
     void updateTempoAccessLevel(List<String> samplePrimaryIds, String accessLevel) throws Exception;
     TempoSample getTempoSampleDataBySamplePrimaryId(String primaryId) throws Exception;
+    void updateSampleInitRunDate(String primaryId) throws Exception;
 }

--- a/service/src/main/java/org/mskcc/smile/service/impl/CohortCompleteServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/CohortCompleteServiceImpl.java
@@ -59,6 +59,10 @@ public class CohortCompleteServiceImpl implements CohortCompleteService {
                         cohort.getLatestCohortComplete().getDate());
                 }
                 cohortCompleteRepository.addCohortSampleRelationship(cohort.getCohortId(), primaryId);
+                // the update needs to happen after the new cohort-sample relationship
+                // is established so that all possible cohort delivery dates are taken into consideration
+                // when potentially updating the pipeline run date
+                tempoService.updateSampleInitRunDate(primaryId);
             } else {
                 unknownSamples.add(sampleId);
             }


### PR DESCRIPTION
# Allow updates to sample init pipeline run date where applicable

Briefly describe changes proposed in this pull request:


This issue arose after noticing that pipeline run dates weren't getting updated if a `Tempo` node already exists for a sample that was delivered as part of a cohort _after_ other `Tempo` data had already been established. I.e., if a sample had BAM/MAF/QC complete events imported first and then a Cohort with that same sample was imported at a later date, the sample's `Tempo` node was not getting updated with an initial pipeline run date or embargo date. 

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Code checks:**
- [x] Endpoints were tested to ensure their integrity.
- [ ] ~~Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.~~
- [ ] ~~Unit tests were updated in relation to updates to the mocked test data.~~ no changes to mocked data needed

### II. Neo4j models and database schema checklist:
- [ ] ~~Neo4j persistence models were changed.~~
- [ ] ~~The graph database produces the expected changes to models, relationships, and/or property names.~~

### III. Message handlers checklist:
- [ ] ~~Changes in this PR affect the workflow of incoming messages.~~
- [x] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
- [ ] ~~Unit tests were added to ensure messages are handled as expected.~~

If no unit tests were updated or added, then please explain why: [insert details here]

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, local docker, **dev server**, production]
- Neo4j [local, local docker, **dev server**, production]
- SMILE Server [local, local docker, **dev server**, production]
- Message publishing simulation [nats cli, docker nats cli, **smile publisher tool**, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
