### PR TITLE
Upload TEMPO samples to AWS s3 bucket

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,6 +39,8 @@ Please follow these checks if any changes were made to any classes in the web, s
 - [ ] Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.
 - [ ] Unit tests were updated in relation to updates to the mocked test data.
 
+If no unit tests were updated or added, then please explain why: [insert details here]
+
 ### II. Neo4j models and database schema checklist:
 - [ ] Neo4j persistence models were changed.
 - [ ] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]
@@ -46,9 +48,6 @@ Please follow these checks if any changes were made to any classes in the web, s
 ### III. Message handlers checklist:
 - [ ] Changes in this PR affect the workflow of incoming messages.
 - [ ] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
-- [ ] Unit tests were added to ensure messages are handled as expected.
-
-If no unit tests were updated or added, then please explain why: [insert details here]
 
 Please describe how the workflow and messaging was tested/simulated:
 
@@ -73,4 +72,4 @@ Other: [insert details on how messages were published or simulated for testing]
 ---
 ### General checklist:
 - [ ] All requested changes and comments have been resolved.
-- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,9 @@ RUN mvn clean install -DskipTests
 
 FROM openjdk:21
 COPY --from=0 /smile-server/server/target/smile_server.jar /smile-server/smile_server.jar
-ENTRYPOINT ["java"]
+
+# copy the entrypoint script and make it executable
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+"${SMILE_CONFIG_HOME}/scripts/saml2aws-setup.sh"
+exec java -jar /smile-server/smile_server.jar

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-"${SMILE_CONFIG_HOME}/scripts/saml2aws-setup.sh"
-exec java -jar /smile-server/smile_server.jar
+"${SMILE_CONFIG_HOME}/scripts/saml2aws-smile-setup.sh"
+exec java -Dspring.main.allow-circular-references=true -jar /smile-server/smile_server.jar

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 "${SMILE_CONFIG_HOME}/scripts/saml2aws-smile-setup.sh"
-exec java -Dspring.main.allow-circular-references=true -jar /smile-server/smile_server.jar
+exec java --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED -Dspring.main.allow-circular-references=true -jar /smile-server/smile_server.jar

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -23,5 +23,11 @@
         <artifactId>protobuf-java-util</artifactId>
         <version>4.26.1</version>
     </dependency>
+    <!-- aws s3 -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>aws-sdk-java</artifactId>
+      <version>2.32.20</version>
+    </dependency>
   </dependencies>
 </project>

--- a/service/src/main/java/org/mskcc/smile/service/AwsS3Service.java
+++ b/service/src/main/java/org/mskcc/smile/service/AwsS3Service.java
@@ -1,0 +1,11 @@
+package org.mskcc.smile.service;
+
+import org.mskcc.smile.commons.generated.Smile;
+
+/**
+ *
+ * @author ochoaa
+ */
+public interface AwsS3Service {
+    void pushTempoSamplesToS3Bucket(Smile.TempoSampleUpdateMessage tempoSampleUpdateMessage);
+}

--- a/service/src/main/java/org/mskcc/smile/service/impl/AwsS3ServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/AwsS3ServiceImpl.java
@@ -1,0 +1,158 @@
+package org.mskcc.smile.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.Instant;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.mskcc.smile.commons.generated.Smile.TempoSample;
+import org.mskcc.smile.commons.generated.Smile.TempoSampleUpdateMessage;
+import org.mskcc.smile.service.AwsS3Service;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+/**
+ *
+ * @author ochoaa
+ */
+@Component
+public class AwsS3ServiceImpl implements AwsS3Service {
+    @Value("${s3.aws_region:}")
+    private String s3Region;
+
+    @Value("${s3.aws_profile:}")
+    private String s3Profile;
+
+    @Value("${s3.aws_tempo_bucket:}")
+    private String s3TempoBucket;
+
+    @Value("${s3.aws_role:}")
+    private String s3Role;
+
+    @Value("${s3.aws_username:}")
+    private String s3Username;
+
+    @Value("${s3.aws_password:}")
+    private String s3Password;
+
+    private static final Log LOG = LogFactory.getLog(AwsS3ServiceImpl.class);
+    private S3Client s3;
+    private static Instant s3SessionTimestamp;
+
+    @Override
+    public void pushTempoSamplesToS3Bucket(TempoSampleUpdateMessage tempoSampleUpdateMessage) {
+        S3Client s3Client = getAwsS3Client();
+        for (TempoSample sample : tempoSampleUpdateMessage.getTempoSamplesList()) {
+            try {
+                Boolean success = pushObjectToS3Bucket(s3Client, sample);
+                if (!success) {
+                    LOG.error("Failed to upload TEMPO sample to s3 bucket: "
+                            + sample.getPrimaryId());
+                }
+            } catch (JsonProcessingException ex) {
+                LOG.error("Error during attempt to upload TEMPO sample to s3 bucket", ex);
+            } catch (InvalidProtocolBufferException ex) {
+                Logger.getLogger(AwsS3ServiceImpl.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+    }
+
+    private Boolean pushObjectToS3Bucket(S3Client s3Client, TempoSample sample)
+            throws JsonProcessingException, InvalidProtocolBufferException {
+        String bucketKey = sample.getPrimaryId() + "_clinical.json";
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(s3TempoBucket)
+                .key(bucketKey)
+                .contentType("application/json")
+                .build();
+
+        // protobuf json printer
+        JsonFormat.Printer printer = JsonFormat.printer().preservingProtoFieldNames();
+        PutObjectResponse response = s3Client.putObject(putObjectRequest,
+                RequestBody.fromString(printer.print(sample.toBuilder().build())));
+        if (response.sdkHttpResponse().isSuccessful()) {
+            return Boolean.TRUE;
+        } else {
+            LOG.error("Failed to upload TEMPO sample: " + sample.getPrimaryId()
+                    + ", with SDK HttpResponse: " + response.sdkHttpResponse().statusText());
+            return Boolean.FALSE;
+        }
+    }
+
+    private S3Client getAwsS3Client() {
+        if (s3 == null || sessionIsExpired(s3)) {
+            try {
+                System.out.println("Creating or refreshing s3 session.");
+                s3SessionTimestamp = Instant.now();
+                generateToken();
+            } catch (InterruptedException | IOException e) {
+                throw new RuntimeException("Error during attempt to authenticate with saml2aws", e);
+            }
+
+            Region region = Region.of(s3Region);
+            try {
+                s3 = S3Client.builder()
+                        .region(region)
+                        .credentialsProvider(ProfileCredentialsProvider.create(s3Profile))
+                        .build();
+                return s3;
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to create s3 client", e);
+            }
+        }
+        return s3;
+    }
+
+    private void generateToken() throws IOException, InterruptedException {
+        String usernameArg = new StringBuilder("--username=")
+                .append(s3Username).toString();
+        String passwordArg = new StringBuilder("--password=")
+                .append(s3Password).toString();
+        String[] saml2AwsCmd = {"saml2aws", "--role", s3Role, "login", "--force",
+            "--mfa=Auto", usernameArg, passwordArg, "--skip-prompt", "--session-duration=3600"};
+        System.out.println("Running SAML2AWS login: " + StringUtils.join(saml2AwsCmd, " "));
+
+        ProcessBuilder loginBuilder = new ProcessBuilder(saml2AwsCmd);
+        Process loginProcess = loginBuilder.start();
+
+        // Read the output of the login process (for debugging or to check success/failure)
+        BufferedReader loginReader = new BufferedReader(new InputStreamReader(loginProcess.getInputStream()));
+        String line;
+        while ((line = loginReader.readLine()) != null) {
+            System.out.println("SAML2AWS Login Output: " + line);
+        }
+
+        int exitCode = loginProcess.waitFor();
+        System.out.println("SAML2AWS Login Exit Code: " + exitCode);
+
+        if (exitCode > 0) {
+            throw new RuntimeException("Failed to run: " + StringUtils.join(saml2AwsCmd, " "));
+        }
+    }
+
+    /**
+     * Simple session expiration check.
+     * @param s3Client
+     * @return Boolean
+     */
+    private Boolean sessionIsExpired(S3Client s3Client) {
+        if (s3Client == null) {
+            return Boolean.TRUE;
+        }
+        Instant expirationTime = s3SessionTimestamp.plusSeconds(3600);
+        return Instant.now().isAfter(expirationTime);
+    }
+}

--- a/service/src/main/java/org/mskcc/smile/service/impl/AwsS3ServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/AwsS3ServiceImpl.java
@@ -129,7 +129,8 @@ public class AwsS3ServiceImpl implements AwsS3Service {
         ProcessBuilder loginBuilder = new ProcessBuilder(saml2AwsCmd);
         Process loginProcess = loginBuilder.start();
         // Read the output of the login process (for debugging or to check success/failure)
-        BufferedReader loginReader = new BufferedReader(new InputStreamReader(loginProcess.getInputStream()));
+        BufferedReader loginReader = new BufferedReader(
+                new InputStreamReader(loginProcess.getInputStream()));
         String line;
         while ((line = loginReader.readLine()) != null) {
             System.out.println("SAML2AWS Login Output: " + line);
@@ -139,7 +140,8 @@ public class AwsS3ServiceImpl implements AwsS3Service {
         System.out.println("SAML2AWS Login Exit Code: " + exitCode);
 
         if (exitCode > 0) {
-            BufferedReader errorReader = new BufferedReader(new InputStreamReader(loginProcess.getErrorStream()));
+            BufferedReader errorReader = new BufferedReader(
+                    new InputStreamReader(loginProcess.getErrorStream()));
             String err;
             while ((err = errorReader.readLine()) != null) {
                 System.out.println("SAML2AWS Error Output: " + err);

--- a/service/src/main/java/org/mskcc/smile/service/impl/AwsS3ServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/AwsS3ServiceImpl.java
@@ -121,13 +121,13 @@ public class AwsS3ServiceImpl implements AwsS3Service {
                 .append(s3Username).toString();
         String passwordArg = new StringBuilder("--password=")
                 .append(s3Password).toString();
-        String[] saml2AwsCmd = {"saml2aws", "--role", s3Role, "login", "--force",
-            "--mfa=Auto", usernameArg, passwordArg, "--skip-prompt", "--session-duration=3600"};
+        String[] saml2AwsCmd = {"saml2aws", "login", "--profile", s3Profile, "--role", s3Role, "--force",
+            "--mfa=Auto", usernameArg, passwordArg, "--skip-prompt", "--session-duration=3600",
+            "--idp-account", s3Profile};
         System.out.println("Running SAML2AWS login: " + StringUtils.join(saml2AwsCmd, " "));
 
         ProcessBuilder loginBuilder = new ProcessBuilder(saml2AwsCmd);
         Process loginProcess = loginBuilder.start();
-
         // Read the output of the login process (for debugging or to check success/failure)
         BufferedReader loginReader = new BufferedReader(new InputStreamReader(loginProcess.getInputStream()));
         String line;
@@ -139,6 +139,11 @@ public class AwsS3ServiceImpl implements AwsS3Service {
         System.out.println("SAML2AWS Login Exit Code: " + exitCode);
 
         if (exitCode > 0) {
+            BufferedReader errorReader = new BufferedReader(new InputStreamReader(loginProcess.getErrorStream()));
+            String err;
+            while ((err = errorReader.readLine()) != null) {
+                System.out.println("SAML2AWS Error Output: " + err);
+            }
             throw new RuntimeException("Failed to run: " + StringUtils.join(saml2AwsCmd, " "));
         }
     }

--- a/service/src/main/java/org/mskcc/smile/service/impl/TempoMessageHandlingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/TempoMessageHandlingServiceImpl.java
@@ -32,6 +32,7 @@ import org.mskcc.smile.model.tempo.QcComplete;
 import org.mskcc.smile.model.tempo.Tempo;
 import org.mskcc.smile.model.tempo.json.CohortCompleteJson;
 import org.mskcc.smile.model.tempo.json.SampleBillingJson;
+import org.mskcc.smile.service.AwsS3Service;
 import org.mskcc.smile.service.CohortCompleteService;
 import org.mskcc.smile.service.SmileSampleService;
 import org.mskcc.smile.service.TempoMessageHandlingService;
@@ -63,9 +64,6 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
     @Value("${tempo.sample_billing_topic}")
     private String TEMPO_SAMPLE_BILLING_TOPIC;
 
-    @Value("${tempo.release_samples_topic}")
-    private String TEMPO_RELEASE_SAMPLES_TOPIC;
-
     @Value("${tempo.update_samples_embargo_topic}")
     private String TEMPO_UPDATE_SAMPLES_EMBARGO_TOPIC;
 
@@ -80,6 +78,9 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
 
     @Autowired
     private CohortCompleteService cohortCompleteService;
+
+    @Autowired
+    private AwsS3Service awsS3Service;
 
     private static Gateway messagingGateway;
     private static final Log LOG = LogFactory.getLog(TempoMessageHandlingServiceImpl.class);
@@ -286,9 +287,8 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                             // tumor-normal pairs are provided as map entries - this block
                             // compiles them into a set list of strings
                             cohortCompleteService.saveCohort(cohort, ccJson.getTumorNormalPairsAsSet());
-
-                            publishTempoSamplesToCBioPortal(ccJson.getTumorPrimaryIdsAsSet(),
-                                    TEMPO_RELEASE_SAMPLES_TOPIC);
+                            // upload to aws s3 bucket
+                            uploadTempoSamplesToAwsS3Bucket(ccJson.getTumorPrimaryIdsAsSet());
                         } else if (cohortCompleteService.hasUpdates(existingCohort,
                                 cohort)) {
                             LOG.info("Received updates for cohort: " + ccJson.getCohortId());
@@ -300,11 +300,9 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                             Set<String> newSamples = ccJson.getTumorNormalPairsAsSet();
                             newSamples.removeAll(existingCohort.getCohortSamplePrimaryIds());
 
-                            // persist updates to db
+                            // persist updates to db and upload to aws s3 bucket
                             cohortCompleteService.saveCohort(existingCohort, newSamples);
-
-                            publishTempoSamplesToCBioPortal(ccJson.getTumorPrimaryIdsAsSet(),
-                                    TEMPO_RELEASE_SAMPLES_TOPIC);
+                            uploadTempoSamplesToAwsS3Bucket(ccJson.getTumorPrimaryIdsAsSet());
                         } else {
                             LOG.error("Cohort " + ccJson.getCohortId()
                                     + " already exists and no new updates were received.");
@@ -354,9 +352,8 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                             tempoService.updateSampleBilling(billing);
 
                             // publish to tempo sample update topic
-                            publishTempoSamplesToCBioPortal(new HashSet<>(
-                                    Arrays.asList(billing.getPrimaryId())),
-                                TEMPO_UPDATE_SAMPLES_EMBARGO_TOPIC);
+                            uploadTempoSamplesToAwsS3Bucket(new HashSet<>(
+                                    Arrays.asList(billing.getPrimaryId())));
                         } else {
                             LOG.error("[TEMPO SAMPLE BILLING ERROR] Cannot update billing information for "
                                     + "sample that does not exist: " + billing.getPrimaryId());
@@ -391,8 +388,7 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                         tempoService.updateTempoAccessLevel(samplePrimaryIds,
                                 TempoServiceImpl.ACCESS_LEVEL_PUBLIC);
                         // publish to tempo sample update topic
-                        publishTempoSamplesToCBioPortal(new HashSet<>(samplePrimaryIds),
-                                TEMPO_UPDATE_SAMPLES_EMBARGO_TOPIC);
+                        uploadTempoSamplesToAwsS3Bucket(new HashSet<>(samplePrimaryIds));
                     }
                 } catch (InterruptedException e) {
                     interrupted = true;
@@ -404,11 +400,11 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
         }
     }
 
-    private void publishTempoSamplesToCBioPortal(Set<String> samplePrimaryIds, String topic)
+    private void uploadTempoSamplesToAwsS3Bucket(Set<String> samplePrimaryIds)
             throws Exception {
         // validate and build tempo samples to publish to cBioPortal
         Set<TempoSample> validTempoSamples = new HashSet<>();
-        LOG.info("Assembling TEMPO data per sample for publishing....");
+        LOG.info("Assembling TEMPO data per sample for uploading to AWS s3 bucket for cBioPortal");
         for (String primaryId : samplePrimaryIds) {
             try {
                 TempoSample tempoSample = tempoService.getTempoSampleDataBySamplePrimaryId(primaryId);
@@ -442,18 +438,19 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
         }
         // bundle together all valid tempo samples and publish to cBioPortal
         if (!validTempoSamples.isEmpty()) {
-            LOG.info("Total samples that will be published = " + validTempoSamples.size());
+            LOG.info("Total samples that will be uploaded to AWS s3 bucket = " + validTempoSamples.size());
             TempoSampleUpdateMessage tempoSampleUpdateMessage = TempoSampleUpdateMessage.newBuilder()
                 .addAllTempoSamples(validTempoSamples)
                 .build();
             try {
-                LOG.info("Publishing TEMPO samples to cBioPortal:\n" + tempoSampleUpdateMessage.toString());
-                messagingGateway.publish(topic, tempoSampleUpdateMessage.toByteArray());
+                LOG.info("Pushing TEMPO samples to AWS s3 bucket for cBioPortal:\n"
+                        + tempoSampleUpdateMessage.toString());
+                awsS3Service.pushTempoSamplesToS3Bucket(tempoSampleUpdateMessage);
             } catch (Exception e) {
-                LOG.error("Error publishing TEMPO samples to cBioPortal", e);
+                LOG.error("Error uploading TEMPO samples to AWS s3 bucket for cBioPortal", e);
             }
         } else {
-            LOG.warn("No valid TEMPO samples to publish to cBioPortal");
+            LOG.warn("No valid TEMPO samples to upload to AWS s3 bucket for cBioPortal");
         }
     }
 

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -70,9 +70,17 @@ tempo.wes_qc_complete_topic=
 tempo.wes_maf_complete_topic=
 tempo.wes_cohort_complete_topic=
 tempo.sample_billing_topic=
-tempo.release_samples_topic=
 tempo.update_samples_embargo_topic=
 
 # dbgap topics
 num.dbgap_msg_handler_threads=
 dbgap.sample_update_topic=
+
+# aws s3 config
+s3.aws_region=
+s3.aws_profile=
+s3.aws_tempo_bucket=
+s3.aws_role=
+s3.aws_username=
+s3.aws_password=
+


### PR DESCRIPTION
# Upload TEMPO samples directly to AWS s3 bucket

Briefly describe changes proposed in this pull request:
- Upload TEMPO sample JSONs directly to AWS s3 bucket
- Remove publishing to RELEASE_TEMPO_SAMPLES topic
 
General notes:
- s3 client connection isn't initialized until the first TEMPO sample is uploaded during runtime. 
- Subsequent TEMPO samples uploaded to AWS s3 bucket will check if the session has expired or not before uploading to s3. If session has expired then. a call to refresh the client connection will be made. 

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Code checks:** n/a
```
- [ ] Endpoints were tested to ensure their integrity.
- [ ] Screenshots have been provided to demonstrate changes made to the response body JSON schema and/or swagger page.
- [ ] Unit tests were updated in relation to updates to the mocked test data.
```

### II. Neo4j models and database schema checklist: n/a
```
- [ ] Neo4j persistence models were changed.
- [ ] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]
```

### III. Message handlers checklist:
- [x] Changes in this PR affect the workflow of incoming messages.
- [x] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, local docker, **dev server**, production]
- Neo4j [local, local docker, **dev server,** production]
- SMILE Server [local, local docker, **dev server**, production]
- Message publishing simulation [nats cli, docker nats cli, smile publisher tool, **other** (describe below)]

Other: SMILE dashboard was used to update TEMPO samples and trigger the upload to s3 bucket

### IV. Configuration and/or permissions checklist: n/a
```
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.
```

---
### General checklist:
- [x] All requested changes and comments have been resolved.
