### PR TITLE
Formatted date to ms timestamp migration

### DIFF
--- a/model/src/main/java/org/mskcc/smile/model/RequestMetadata.java
+++ b/model/src/main/java/org/mskcc/smile/model/RequestMetadata.java
@@ -13,7 +13,7 @@ public class RequestMetadata implements Serializable, Comparable<RequestMetadata
     private Long id;
     private String igoRequestId;
     private String requestMetadataJson;
-    private String importDate;
+    private Long importDate;
     @Relationship(type = "HAS_STATUS", direction = Relationship.Direction.OUTGOING)
     private Status status;
 
@@ -23,7 +23,7 @@ public class RequestMetadata implements Serializable, Comparable<RequestMetadata
      * @param requestMetadataJson
      * @param importDate
      */
-    public RequestMetadata(String igoRequestId, String requestMetadataJson, String importDate) {
+    public RequestMetadata(String igoRequestId, String requestMetadataJson, Long importDate) {
         this.igoRequestId = igoRequestId;
         this.requestMetadataJson = requestMetadataJson;
         this.importDate = importDate;
@@ -53,11 +53,11 @@ public class RequestMetadata implements Serializable, Comparable<RequestMetadata
         this.requestMetadataJson = requestMetadataJson;
     }
 
-    public String getImportDate() {
+    public Long getImportDate() {
         return importDate;
     }
 
-    public void setImportDate(String importDate) {
+    public void setImportDate(Long importDate) {
         this.importDate = importDate;
     }
 

--- a/model/src/main/java/org/mskcc/smile/model/SampleMetadata.java
+++ b/model/src/main/java/org/mskcc/smile/model/SampleMetadata.java
@@ -34,7 +34,7 @@ public class SampleMetadata implements Serializable, Comparable<SampleMetadata>,
     private String cmoSampleName;
     private String sampleName;
     private String igoRequestId;
-    private String importDate;
+    private Long importDate;
     private String cmoInfoIgoId;
     private String oncotreeCode;
     private String collectionYear;
@@ -124,11 +124,11 @@ public class SampleMetadata implements Serializable, Comparable<SampleMetadata>,
         this.id = id;
     }
 
-    public String getImportDate() {
+    public Long getImportDate() {
         return importDate;
     }
 
-    public void setImportDate(String importDate) {
+    public void setImportDate(Long importDate) {
         this.importDate = importDate;
     }
 

--- a/model/src/main/java/org/mskcc/smile/model/web/PublishedSmileSample.java
+++ b/model/src/main/java/org/mskcc/smile/model/web/PublishedSmileSample.java
@@ -30,7 +30,7 @@ public class PublishedSmileSample {
     private String sampleName;
     private String cmoInfoIgoId;
     private String investigatorSampleId;
-    private String importDate;
+    private Long importDate;
     private String sampleType;
     private String oncotreeCode;
     private String collectionYear;
@@ -113,11 +113,11 @@ public class PublishedSmileSample {
         this.smileSampleId = smileSampleId;
     }
 
-    public String getImportDate() {
+    public Long getImportDate() {
         return importDate;
     }
 
-    public void setImportDate(String importDate) {
+    public void setImportDate(Long importDate) {
         this.importDate = importDate;
     }
 

--- a/model/src/main/java/org/mskcc/smile/model/web/SmileSampleIdMapping.java
+++ b/model/src/main/java/org/mskcc/smile/model/web/SmileSampleIdMapping.java
@@ -2,7 +2,6 @@ package org.mskcc.smile.model.web;
 
 import java.util.UUID;
 import org.apache.commons.lang.builder.ToStringBuilder;
-import org.mskcc.smile.model.SampleMetadata;
 import org.neo4j.ogm.annotation.typeconversion.Convert;
 import org.neo4j.ogm.typeconversion.UuidStringConverter;
 
@@ -21,18 +20,6 @@ public class SmileSampleIdMapping {
      * SmileSampleIdMapping constructor.
      */
     public SmileSampleIdMapping() {}
-
-    /**
-     * SmileSampleIdMapping constructor.
-     * @param smileSampleId
-     * @param sampleMetadata
-     */
-    public SmileSampleIdMapping(UUID smileSampleId, SampleMetadata sampleMetadata) {
-        this.smileSampleId = smileSampleId;
-        this.importDate = sampleMetadata.getImportDate();
-        this.primaryId = sampleMetadata.getPrimaryId();
-        this.cmoSampleName = sampleMetadata.getCmoSampleName();
-    }
 
     public UUID getSmileSampleId() {
         return smileSampleId;

--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileRequestRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileRequestRepository.java
@@ -17,7 +17,8 @@ import org.springframework.stereotype.Repository;
 public interface SmileRequestRepository extends Neo4jRepository<SmileRequest, Long> {
     @Query("""
            MATCH (r: Request {igoRequestId: $reqId})
-           RETURN r
+           OPTIONAL MATCH (r)-[hm:HAS_METADATA]->(rm: RequestMetadata)-[hs:HAS_STATUS]->(rs: Status)
+           RETURN r, rm, rs, hm, hs
            """)
     SmileRequest findRequestById(@Param("reqId") String reqId);
 
@@ -36,10 +37,11 @@ public interface SmileRequestRepository extends Neo4jRepository<SmileRequest, Lo
     List<RequestMetadata> findRequestMetadataHistoryByRequestId(@Param("reqId") String reqId);
 
     @Query("""
-           MATCH (r: Request)-[:HAS_METADATA]->(rm: RequestMetadata)
+           MATCH (r: Request)-[hm:HAS_METADATA]->(rm: RequestMetadata)
            WHERE $dateRangeStart <= [rm][0].importDate <= $dateRangeEnd
-           RETURN DISTINCT [r.smileRequestId, r.igoProjectId, r.igoRequestId]
+           RETURN DISTINCT ({smileRequestId: r.smileRequestId,
+           projectId: r.igoProjectId, requestId: r.igoRequestId})
            """)
-    List<List<String>> findRequestWithinDateRange(@Param("dateRangeStart") String startDate,
-            @Param("dateRangeEnd") String endDate);
+    List<Object> findRequestWithinDateRange(@Param("dateRangeStart") Long startDate,
+            @Param("dateRangeEnd") Long endDate);
 }

--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileSampleRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileSampleRepository.java
@@ -116,9 +116,11 @@ public interface SmileSampleRepository extends Neo4jRepository<SmileSample, UUID
     @Query("""
            MATCH (s: Sample {sampleCategory: 'research'})-[:HAS_METADATA]->(sm: SampleMetadata)
            WHERE sm.importDate >= $inputDate
-           RETURN DISTINCT s.smileSampleId
+           RETURN DISTINCT ({smileSampleId: s.smileSampleId,
+            importDate: apoc.date.format(sm.importDate, "ms", "yyyy-MM-dd"),
+            primaryId: sm.primaryId, cmoSampleName: sm.cmoSampleName})
            """)
-    List<UUID> findSamplesByLatestImportDate(@Param("inputDate") String inputDate);
+    List<Object> findSamplesByLatestImportDate(@Param("inputDate") Long inputDate);
 
     @Query("""
            MATCH (s: Sample {smileSampleId: $smileSampleId})-[:HAS_METADATA]->(sm: SampleMetadata)

--- a/scripts/migrate.cypher
+++ b/scripts/migrate.cypher
@@ -188,3 +188,9 @@ WHERE cc.importDate IS NULL
 SET cc.importDate = apoc.date.parse(cc.date, "ms", "yyyy-MM-dd HH:mm")
 return cc
 
+// convert dates to timestamps for request and sample metadata nodes
+MATCH (rm: RequestMetadata)
+SET rm.importDate = apoc.date.parse(rm.importDate, "ms", "yyyy-MM-dd")
+
+MATCH (sm: SampleMetadata)
+SET sm.importDate = apoc.date.parse(sm.importDate, "ms", "yyyy-MM-dd")

--- a/service/src/main/java/org/mskcc/smile/service/util/RequestDataFactory.java
+++ b/service/src/main/java/org/mskcc/smile/service/util/RequestDataFactory.java
@@ -3,8 +3,7 @@ package org.mskcc.smile.service.util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -94,7 +93,7 @@ public class RequestDataFactory {
         RequestMetadata requestMetadata = new RequestMetadata(
                 requestId.toString(),
                 mapper.writeValueAsString(requestMetadataMap),
-                LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
+                Instant.now().toEpochMilli());
         requestMetadata.setStatus(extractStatusFromJson(requestMetadataJson));
         return requestMetadata;
     }

--- a/service/src/main/java/org/mskcc/smile/service/util/SampleDataFactory.java
+++ b/service/src/main/java/org/mskcc/smile/service/util/SampleDataFactory.java
@@ -5,8 +5,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -58,7 +57,7 @@ public class SampleDataFactory {
             SampleMetadata sampleMetadata, Boolean isCmoRequest, Status sampleStatus) {
         sampleMetadata.setIgoRequestId(requestId);
         if (sampleMetadata.getImportDate() == null) {
-            sampleMetadata.setImportDate(LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
+            sampleMetadata.setImportDate(Instant.now().toEpochMilli());
         }
         sampleMetadata.addAdditionalProperty("igoRequestId", requestId);
         if (isCmoRequest != null) {
@@ -119,7 +118,7 @@ public class SampleDataFactory {
     public static SmileSample buildNewClinicalSampleFromMetadata(String cmoPatientId,
             DmpSampleMetadata dmpSampleMetadata) throws ParseException {
         SampleMetadata sampleMetadata = buildNewSampleMetadataFromDmpSample(cmoPatientId, dmpSampleMetadata);
-        sampleMetadata.setImportDate(LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
+        sampleMetadata.setImportDate(Instant.now().toEpochMilli());
 
         SmileSample sample = new SmileSample();
         sample.addSampleMetadata(sampleMetadata);
@@ -145,8 +144,7 @@ public class SampleDataFactory {
             throws JsonProcessingException {
         SampleMetadata sampleMetadata =
                 mapper.readValue(sampleMetadataJson, SampleMetadata.class);
-        sampleMetadata.setImportDate(
-                LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE));
+        sampleMetadata.setImportDate(Instant.now().toEpochMilli());
 
         // standardize value for sex (M -> Male, F -> Female)
         String sex = resolveIgoSampleSex(sampleMetadata.getSex());

--- a/service/src/test/java/org/mskcc/smile/service/SampleServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/SampleServiceTest.java
@@ -1,6 +1,7 @@
 package org.mskcc.smile.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -370,7 +371,7 @@ public class SampleServiceTest {
     public void testFindLatestSampleMetadataAfterUpdatingNewPredatedSample() throws Exception {
         String requestId = "MOCKREQUEST1_B";
         String igoId = "MOCKREQUEST1_B_2";
-        String importDate = "2000-06-10";
+        Long importDate = 960595200000L; // "2000-06-10" in ms
 
         SampleMetadata sampleMetadata = sampleService.getResearchSampleByRequestAndIgoId(
                 requestId, igoId).getLatestSampleMetadata();
@@ -387,6 +388,16 @@ public class SampleServiceTest {
         Assertions.assertNotEquals(importDate, updatedSampleMetadataAfterUpdate.getImportDate());
         Assertions.assertEquals(sampleMetadata.getImportDate(),
                 updatedSampleMetadataAfterUpdate.getImportDate());
+
+        SampleMetadata updatedSampleType = (SampleMetadata) updatedSampleMetadataAfterUpdate.clone();
+        updatedSampleType.setImportDate(Instant.now().toEpochMilli());
+        updatedSampleType.setSampleType("Metastasis");
+        SmileSample sample = sampleService.getSampleByInputId(igoId);
+        sample.updateSampleMetadata(updatedSampleType);
+        sampleService.saveSmileSample(sample);
+        SampleMetadata latest = sampleService.getResearchSampleByRequestAndIgoId(
+                requestId, igoId).getLatestSampleMetadata();
+        Assertions.assertEquals("Metastasis", latest.getSampleType());
     }
 
     /**
@@ -399,7 +410,7 @@ public class SampleServiceTest {
     public void testFindLatestSampleMetadataAfterSavingNewPredatedSample() throws Exception {
         String requestId = "MOCKREQUEST1_B";
         String igoId = "MOCKREQUEST1_B_3";
-        String importDate = "2000-06-10";
+        Long importDate = 960595200000L; // "2000-06-10" in ms
 
         SampleMetadata sampleMetadata = sampleService.getResearchSampleByRequestAndIgoId(
                 requestId, igoId).getLatestSampleMetadata();
@@ -521,7 +532,7 @@ public class SampleServiceTest {
 
         String invalidCollectionYear = "INVALID IGO UPDATE";
         SampleMetadata updatedMetadata = updatedSample.getLatestSampleMetadata();
-        updatedMetadata.setImportDate("2000-10-15");
+        updatedMetadata.setImportDate(971568000000L); // 2000-10-15 in ms
         updatedMetadata.setBaitSet("NEW BAIT SET");
         updatedMetadata.setGenePanel("NEW GENE PANEL");
         updatedMetadata.setCollectionYear(invalidCollectionYear);

--- a/web/src/main/java/org/mskcc/smile/web/RequestController.java
+++ b/web/src/main/java/org/mskcc/smile/web/RequestController.java
@@ -110,7 +110,8 @@ public class RequestController {
             method = RequestMethod.POST,
             produces = "application/json")
     public ResponseEntity<Object> fetchRequestsByImportDatePOST(@Parameter(description =
-            "JSON with 'startDate' (required) and 'endDate' (optional) to query for.", required = true)
+            "JSON with 'startDate' (required) and 'endDate' (optional) to query for as yyyy-MM-dd",
+            required = true)
             @RequestBody DateRange dateRange,  ReturnTypeDetails returnType) throws Exception {
         // get request summary for given date range
         List<RequestSummary> requestSummaryList;

--- a/web/src/main/java/org/mskcc/smile/web/SampleController.java
+++ b/web/src/main/java/org/mskcc/smile/web/SampleController.java
@@ -79,7 +79,7 @@ public class SampleController {
      * @return ResponseEntity
      * @throws Exception
      */
-    @Operation(description = "Fetch SmileSampleIdMapping list by inputDate")
+    @Operation(description = "Fetch SmileSampleIdMapping list by inputDate (yyyy-MM-dd)")
     @RequestMapping(value = "/samplesByDate/{importDate}",
         method = RequestMethod.GET,
         produces = "application/json")


### PR DESCRIPTION
# Formatted date to ms timestamp migration

Briefly describe changes proposed in this pull request:
- Simplified 'samplesByDate' query
- Sample Metadata use of timestamps instead of formatted dates
- Request Metadata use of timestamps instead of formatted dates
- Update migration.cypher with timestamp conversion
- Added unit test for confirming latest metadata
- Updated query for samples by import date

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Code checks:**
- [x] Endpoints were tested to ensure their integrity.
- [x] Unit tests were updated in relation to updates to the mocked test data.

### II. Neo4j models and database schema checklist:
- [x] Neo4j persistence models were changed.
- [x] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]

### III. Message handlers checklist:
- [ ] ~~Changes in this PR affect the workflow of incoming messages.~~
- [x] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS: dev server
- Neo4j: dev server
- SMILE Server: dev server
- Message publishing simulation: smile publisher tool & smile dashboard

### IV. Configuration and/or permissions checklist: n/a
```
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.
```

---
### General checklist:
- [ ] All requested changes and comments have been resolved.

