### PR TITLE
Fix initialized pipeline run dates for TEMPO nodes

### DIFF
--- a/model/src/main/java/org/mskcc/smile/model/tempo/Tempo.java
+++ b/model/src/main/java/org/mskcc/smile/model/tempo/Tempo.java
@@ -28,8 +28,8 @@ public class Tempo implements Serializable {
     private Boolean billed;
     private String billedBy;
     private String costCenter;
-    private String initialPipelineRunDate;
-    private String embargoDate;
+    private String initialPipelineRunDate; // yyyy-MM-dd
+    private String embargoDate; // yyyy-MM-dd
     @Relationship(type = "HAS_EVENT", direction = Relationship.Direction.OUTGOING)
     private List<BamComplete> bamCompleteEvents;
     @Relationship(type = "HAS_EVENT", direction = Relationship.Direction.OUTGOING)

--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/TempoRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/TempoRepository.java
@@ -200,7 +200,10 @@ public interface TempoRepository extends Neo4jRepository<Tempo, UUID> {
            }[0] AS earliestDeliveryDate
            WITH custodianInformation, s.smileSampleId as smileSampleId, earliestDeliveryDate,
            CASE WHEN (earliestDeliveryDate IS NULL OR earliestDeliveryDate = "")
-            THEN $ccDeliveryDate ELSE earliestDeliveryDate END AS initialPipelineRunDate
+            THEN apoc.date.parse($ccDeliveryDate,"ms","yyyy-MM-dd HH:mm")
+            ELSE apoc.date.parse(earliestDeliveryDate,"ms","yyyy-MM-dd HH:mm") END AS initPipelineRunDatetime
+           WITH custodianInformation, smileSampleId, earliestDeliveryDate,
+            apoc.date.format(initPipelineRunDatetime, "ms", "yyyy-MM-dd") AS initialPipelineRunDate
            WITH custodianInformation, smileSampleId, earliestDeliveryDate, initialPipelineRunDate,
            CASE WHEN (initialPipelineRunDate IS NULL OR initialPipelineRunDate = "") THEN ""
             ELSE  apoc.temporal.format(datetime(apoc.date.format(
@@ -244,17 +247,17 @@ public interface TempoRepository extends Neo4jRepository<Tempo, UUID> {
               AND (earliestDeliveryDate IS NULL)) THEN ""
             ELSE CASE WHEN (t.initialPipelineRunDate IS NULL OR t.initialPipelineRunDate = ""
               OR earliestDeliveryDate < t.initialPipelineRunDate)
-            THEN earliestDeliveryDate
-            ELSE t.initialPipelineRunDate
+            THEN apoc.date.parse(earliestDeliveryDate,"ms","yyyy-MM-dd HH:mm")
+            ELSE apoc.date.parse(t.initialPipelineRunDate,"ms","yyyy-MM-dd")
             END
-           END AS updatedInitRundate
-           SET t.initialPipelineRunDate = updatedInitRundate
+           END AS updatedInitRundatetime
+           SET t.initialPipelineRunDate = apoc.date.format(updatedInitRundatetime,"ms","yyyy-MM-dd")
            WITH s, t, today,
            CASE WHEN (t.initialPipelineRunDate IS NULL OR t.initialPipelineRunDate = "")
             THEN ""
             ELSE apoc.temporal.format(datetime(
               apoc.date.format(apoc.date.parse(t.initialPipelineRunDate, "ms", "yyyy-MM-dd"),
-              "ms", "yyyy-MM-dd")) + Duration({months:18}), 'YYYY-MM-dd')
+              "ms", "yyyy-MM-dd")) + Duration({months:18}), 'yyyy-MM-dd')
            END as updatedEmbargoDate
            SET t.embargoDate = updatedEmbargoDate
            WITH s,t,today,

--- a/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
@@ -427,6 +427,26 @@ public class TempoServiceTest {
     }
 
     @Test
+    public void testInitAndSaveBatchTempoDataWithFallbackToCohortDate() throws Exception {
+        // use a tumor sample that doet not belong to an existing cohort
+        String igoId = "MOCKREQUEST1_B_3";
+        Tempo preTempo = tempoService.getTempoDataBySamplePrimaryId(igoId);
+        Assertions.assertNull(preTempo);
+
+        // call batch create tempo nodes for current sample
+        SmileSample sample = sampleService.getSampleByInputId(igoId);
+        String fallbackCohortDate = "2024-06-01 12:00";
+        Integer actual =
+                tempoService.batchCreateTempoNodesForSamplePrimaryIds(
+                        Arrays.asList("MOCKREQUEST1_B_3"), fallbackCohortDate);
+        Assertions.assertEquals(1, actual);
+        Tempo tempo = tempoService.getTempoDataBySampleId(sample);
+        // verify that the tempo dates are set based on the fallback date
+        Assertions.assertEquals("2024-06-01", tempo.getInitialPipelineRunDate());
+        Assertions.assertEquals("2025-12-01", tempo.getEmbargoDate());
+    }
+
+    @Test
     public void testCohortCompletePipelineVersionNull() throws Exception {
         CohortCompleteJson ccJson = getCohortEventData("mockCohortCompleteCCSPPPQQQQ");
         cohortCompleteService.saveCohort(new Cohort(ccJson), ccJson.getTumorNormalPairsAsSet());


### PR DESCRIPTION
# Fix initialized pipeline run dates for TEMPO nodes

Briefly describe changes proposed in this pull request:
- pipeline run dates were getting set to the wrong date format by default when using the batch create method

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Code checks:**
- [ ] Endpoints were tested to ensure their integrity.
- [ ] Unit tests were updated in relation to updates to the mocked test data.

If no unit tests were updated or added, then please explain why: [insert details here]

### II. Neo4j models and database schema checklist:
- [ ] Neo4j persistence models were changed.
- [ ] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]

### III. Message handlers checklist:
- [ ] Changes in this PR affect the workflow of incoming messages.
- [ ] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS: [local, local docker, dev server, production]
- Neo4j: [local, local docker, dev server, production]
- SMILE Server: [local, local docker, dev server, production]
- Message publishing simulation: [nats cli, docker nats cli, smile publisher tool, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### IV. Configuration and/or permissions checklist:
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.

---
### Screenshots

---
### General checklist:
- [ ] All requested changes and comments have been resolved.

