### PR TITLE
Support provisional cohorts in SMILE

### DIFF
--- a/model/src/main/java/org/mskcc/smile/model/tempo/Cohort.java
+++ b/model/src/main/java/org/mskcc/smile/model/tempo/Cohort.java
@@ -24,6 +24,7 @@ public class Cohort implements Serializable {
     @Id @GeneratedValue
     private Long id;
     private String cohortId;
+    private String cohortStatus;
     @Relationship(type = "HAS_COHORT_COMPLETE", direction = Relationship.Direction.OUTGOING)
     private List<CohortComplete> cohortCompleteList;
     @Relationship(type = "HAS_COHORT_SAMPLE", direction = Relationship.Direction.OUTGOING)
@@ -31,8 +32,13 @@ public class Cohort implements Serializable {
 
     public Cohort() {}
 
+    /**
+     * Constructor with CCJson and status.
+     * @param ccJson
+     */
     public Cohort(CohortCompleteJson ccJson) {
         this.cohortId = ccJson.getCohortId();
+        this.cohortStatus = ccJson.getCohortStatus();
         addCohortComplete(new CohortComplete(ccJson));
     }
 
@@ -50,6 +56,14 @@ public class Cohort implements Serializable {
 
     public void setCohortId(String cohortId) {
         this.cohortId = cohortId;
+    }
+
+    public String getCohortStatus() {
+        return cohortStatus;
+    }
+
+    public void setCohortStatus(String cohortStatus) {
+        this.cohortStatus = cohortStatus;
     }
 
     /**

--- a/model/src/main/java/org/mskcc/smile/model/tempo/json/CohortCompleteJson.java
+++ b/model/src/main/java/org/mskcc/smile/model/tempo/json/CohortCompleteJson.java
@@ -36,6 +36,7 @@ public class CohortCompleteJson implements Serializable {
     private String status;
     @JsonProperty("pipelineVersion")
     private String pipelineVersion;
+    private String cohortStatus;
 
     public CohortCompleteJson() {}
 
@@ -148,6 +149,14 @@ public class CohortCompleteJson implements Serializable {
             }
         }
         return primaryIds;
+    }
+
+    public String getCohortStatus() {
+        return cohortStatus;
+    }
+
+    public void setCohortStatus(String cohortStatus) {
+        this.cohortStatus = cohortStatus;
     }
 
     @Override

--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/TempoRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/TempoRepository.java
@@ -251,7 +251,12 @@ public interface TempoRepository extends Neo4jRepository<Tempo, UUID> {
             ELSE apoc.date.parse(t.initialPipelineRunDate,"ms","yyyy-MM-dd")
             END
            END AS updatedInitRundatetime
-           SET t.initialPipelineRunDate = apoc.date.format(updatedInitRundatetime,"ms","yyyy-MM-dd")
+           WITH s,t,today, updatedInitRundatetime,
+            CASE WHEN (updatedInitRundatetime IS NULL OR updatedInitRundatetime = "")
+              THEN ""
+              ELSE apoc.date.format(updatedInitRundatetime,"ms","yyyy-MM-dd")
+            END AS finalUpdatedInitRundatetime
+           SET t.initialPipelineRunDate = finalUpdatedInitRundatetime
            WITH s, t, today,
            CASE WHEN (t.initialPipelineRunDate IS NULL OR t.initialPipelineRunDate = "")
             THEN ""

--- a/scripts/migrate.cypher
+++ b/scripts/migrate.cypher
@@ -194,3 +194,8 @@ SET rm.importDate = apoc.date.parse(rm.importDate, "ms", "yyyy-MM-dd")
 
 MATCH (sm: SampleMetadata)
 SET sm.importDate = apoc.date.parse(sm.importDate, "ms", "yyyy-MM-dd")
+
+// add cohortStatus to Cohort node
+MATCH (c: Cohort)
+SET c.cohortStatus = "DELIVERED"
+

--- a/service/src/main/java/org/mskcc/smile/service/TempoMessageHandlingService.java
+++ b/service/src/main/java/org/mskcc/smile/service/TempoMessageHandlingService.java
@@ -23,5 +23,6 @@ public interface TempoMessageHandlingService {
     void tempoEmbargoStatusHandler(List<String> samplePrimaryIds) throws Exception;
     void uploadSamplesToS3BucketHandler(List<String> samplePrimaryIds) throws Exception;
     void updateTempoCohortHandler(CohortCompleteJson ccJson) throws Exception;
+    void provisionalCohortHandler(CohortCompleteJson ccJson) throws Exception;
     void shutdown() throws Exception;
 }

--- a/service/src/main/java/org/mskcc/smile/service/impl/CohortCompleteServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/CohortCompleteServiceImpl.java
@@ -44,6 +44,10 @@ public class CohortCompleteServiceImpl implements CohortCompleteService {
     @Override
     @Transactional(rollbackFor = {Exception.class})
     public void saveCohort(Cohort cohort, Set<String> sampleIds) throws Exception {
+        if (StringUtils.isBlank(cohort.getCohortStatus())) {
+            cohort.setCohortStatus("DELIVERED");
+        }
+
         // persist new cohort complete event to the db
         cohortCompleteRepository.save(cohort);
         if (sampleIds == null || sampleIds.isEmpty()) {
@@ -151,10 +155,22 @@ public class CohortCompleteServiceImpl implements CohortCompleteService {
     @Override
     public Boolean hasUpdates(Cohort existingCohort, Cohort cohort) throws Exception {
         // check cohort complete data for updates first
-        Boolean hasUpdates = hasCohortCompleteUpdates(existingCohort, cohort);
+        if (hasCohortCompleteUpdates(existingCohort, cohort)) {
+            return Boolean.TRUE;
+        }
+        // check for change in cohort status
+        if (!StringUtils.isBlank(existingCohort.getCohortStatus())
+                && !StringUtils.isBlank(cohort.getCohortStatus())
+                && !existingCohort.getCohortStatus().equals(cohort.getCohortStatus())) {
+            return Boolean.TRUE;
+        }
+        // check for change in cohort samples list
         Set<String> newSamples = cohort.getCohortSamplePrimaryIds();
         newSamples.removeAll(existingCohort.getCohortSamplePrimaryIds());
-        return (hasUpdates || !newSamples.isEmpty());
+        if (!newSamples.isEmpty()) {
+            return Boolean.TRUE;
+        }
+        return Boolean.FALSE;
     }
 
     @Override

--- a/service/src/main/java/org/mskcc/smile/service/impl/TempoMessageHandlingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/TempoMessageHandlingServiceImpl.java
@@ -78,6 +78,9 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
     @Value("${tempo.update_cohort_pub_topic:}")
     private String TEMPO_UPDATE_COHORT_PUB_TOPIC;
 
+    @Value("${tempo.provisional_cohort_sub_topic}")
+    private String TEMPO_PROVISIONAL_COHORT_SUB_TOPIC;
+
     @Value("${num.tempo_msg_handler_threads:1}")
     private int NUM_TEMPO_MSG_HANDLERS;
 
@@ -117,6 +120,8 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
             new LinkedBlockingQueue<List<String>>();
     private static final BlockingQueue<CohortCompleteJson> updateTempoCohortQueue =
             new LinkedBlockingQueue<CohortCompleteJson>();
+    private static final BlockingQueue<CohortCompleteJson> provisionalCohortQueue =
+            new LinkedBlockingQueue<CohortCompleteJson>();
 
     private static CountDownLatch bamCompleteHandlerShutdownLatch;
     private static CountDownLatch qcCompleteHandlerShutdownLatch;
@@ -126,6 +131,7 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
     private static CountDownLatch tempoEmbargoStatusHandlerShutdownLatch;
     private static CountDownLatch uploadSamplesToS3HandlerShutdownLatch;
     private static CountDownLatch updateTempoCohortHandlerShutdownLatch;
+    private static CountDownLatch provisionalCohortHandlerShutdownLatch;
 
     private class BamCompleteHandler implements Runnable {
         final Phaser phaser;
@@ -310,6 +316,7 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                         } else if (cohortCompleteService.hasUpdates(existingCohort,
                                 cohort)) {
                             LOG.info("Received updates for cohort: " + ccJson.getCohortId());
+                            existingCohort.setCohortStatus("DELIVERED");
                             if (cohortCompleteService.hasCohortCompleteUpdates(existingCohort, cohort)) {
                                 existingCohort.addCohortComplete(cohort.getLatestCohortComplete());
                             }
@@ -534,6 +541,52 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
         }
     }
 
+    private class ProvisionalCohortHandler implements Runnable {
+        final Phaser phaser;
+        boolean interrupted = false;
+
+        ProvisionalCohortHandler(Phaser phaser) {
+            this.phaser = phaser;
+        }
+
+        @Override
+        public void run() {
+            phaser.arrive();
+            while (true) {
+                try {
+                    CohortCompleteJson ccJson
+                            = provisionalCohortQueue.poll(100, TimeUnit.MILLISECONDS);
+                    if (ccJson != null) {
+                        Cohort cohort = new Cohort(ccJson);
+                        Cohort existingCohort =
+                                cohortCompleteService.getCohortByCohortId(ccJson.getCohortId());
+
+                        // if cohort does not already exist then persist as provisional cohort
+                        if (existingCohort == null) {
+                            LOG.info("Persisting provisional cohort to SMILE...");
+                            cohortCompleteService.saveCohort(cohort,
+                                    ccJson.getTumorPrimaryIdsAsSet());
+                        } else if (cohortCompleteService.hasUpdates(existingCohort,
+                                cohort)) {
+                            LOG.info("Received updates for provisional cohort: " + ccJson.getCohortId());
+                            existingCohort.addCohortComplete(cohort.getLatestCohortComplete());
+                            cohortCompleteService.saveCohort(existingCohort,
+                                    ccJson.getTumorPrimaryIdsAsSet());
+                        } else {
+                            LOG.error("No new updates to persist for provisional cohort:  "
+                                    + ccJson.getCohortId());
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                } catch (Exception e) {
+                    LOG.error("Error during handling of provisional cohort message", e);
+                }
+                provisionalCohortHandlerShutdownLatch.countDown();
+            }
+        }
+    }
+
     private TempoSampleUpdateMessage genTempoSampleUpdateMessage(Set<String> samplePrimaryIds)
             throws Exception {
         // validate and build tempo samples to publish to cBioPortal
@@ -615,6 +668,7 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
             setupTempoEmbargoStatusHandler(messagingGateway, this);
             setupUploadSamplesToS3BucketHandler(messagingGateway, this);
             setupUpdateTempoCohortHandler(messagingGateway, this);
+            setupProvisionalCohortHandler(messagingGateway, this);
             initializeMessageHandlers();
             initialized = true;
         } else {
@@ -730,6 +784,21 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
     }
 
     @Override
+    public void provisionalCohortHandler(CohortCompleteJson ccJson) throws Exception {
+        if (!initialized) {
+            throw new IllegalStateException("Message Handling Service has not been initialized");
+        }
+        if (!shutdownInitiated) {
+            provisionalCohortQueue.put(ccJson);
+        } else {
+            LOG.error("Shutdown initiated, not accepting request to persist provisional TEMPO cohort: "
+                    + ccJson);
+            throw new IllegalStateException("Shutdown initiated, not handling any "
+                    + "more provisional TEMPO cohort events");
+        }
+    }
+
+    @Override
     public void shutdown() throws Exception {
         if (!initialized) {
             throw new IllegalStateException("Message Handling Service has not been initialized");
@@ -743,6 +812,7 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
         tempoEmbargoStatusHandlerShutdownLatch.await();
         uploadSamplesToS3HandlerShutdownLatch.await();
         updateTempoCohortHandlerShutdownLatch.await();
+        provisionalCohortHandlerShutdownLatch.await();
         shutdownInitiated = true;
     }
 
@@ -826,6 +896,16 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
             exec.execute(new UpdateTempoCohortHandler(updateTempoCohortPhaser));
         }
         updateTempoCohortPhaser.arriveAndAwaitAdvance();
+
+        // provisional cohort handler
+        provisionalCohortHandlerShutdownLatch = new CountDownLatch(NUM_TEMPO_MSG_HANDLERS);
+        final Phaser provisionalCohortPhaser = new Phaser();
+        provisionalCohortPhaser.register();
+        for (int lc = 0; lc < NUM_TEMPO_MSG_HANDLERS; lc++) {
+            provisionalCohortPhaser.register();
+            exec.execute(new ProvisionalCohortHandler(provisionalCohortPhaser));
+        }
+        provisionalCohortPhaser.arriveAndAwaitAdvance();
     }
 
     private void setupBamCompleteHandler(Gateway gateway,
@@ -946,7 +1026,7 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                     CohortCompleteJson cohortCompleteData =
                             (CohortCompleteJson) NatsMsgUtil.convertObjectFromString(
                                     cohortCompleteJson, new TypeReference<CohortCompleteJson>() {});
-
+                    cohortCompleteData.setCohortStatus("DELIVERED");
                     tempoMessageHandlingService.cohortCompleteHandler(cohortCompleteData);
                 } catch (Exception e) {
                     LOG.error("Exception occurred during processing of Cohort Complete event: "
@@ -1045,11 +1125,37 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                     }
                     CohortCompleteJson ccJson = (CohortCompleteJson) NatsMsgUtil.convertObjectFromString(
                                     ccJsonString, new TypeReference<CohortCompleteJson>() {});
+                    ccJson.setCohortStatus("DELIVERED");
                     tempoMessageHandlingService.updateTempoCohortHandler(ccJson);
                 } catch (Exception e) {
                     LOG.error("Exception occurred during processing of TEMPO "
                             + "cohort update message: "
                             + TEMPO_UPDATE_COHORT_SUB_TOPIC, e);
+                }
+            }
+        });
+    }
+
+    private void setupProvisionalCohortHandler(Gateway gateway,
+            TempoMessageHandlingService tempoMessageHandlingService) throws Exception {
+        gateway.subscribe(TEMPO_PROVISIONAL_COHORT_SUB_TOPIC, Object.class, new MessageConsumer() {
+            @Override
+            public void onMessage(Message msg, Object message) {
+                try {
+                    LOG.info("Received message on topic: " + TEMPO_PROVISIONAL_COHORT_SUB_TOPIC);
+                    String ccJsonString = NatsMsgUtil.extractNatsJsonString(msg);
+                    if (ccJsonString == null) {
+                        LOG.error("Exception occurred during processing of NATS message data");
+                        return;
+                    }
+                    CohortCompleteJson ccJson = (CohortCompleteJson) NatsMsgUtil.convertObjectFromString(
+                                    ccJsonString, new TypeReference<CohortCompleteJson>() {});
+                    ccJson.setCohortStatus("PROVISIONAL");
+                    tempoMessageHandlingService.provisionalCohortHandler(ccJson);
+                } catch (Exception e) {
+                    LOG.error("Exception occurred during processing of provisional TEMPO "
+                            + "cohort message: "
+                            + TEMPO_PROVISIONAL_COHORT_SUB_TOPIC, e);
                 }
             }
         });

--- a/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
@@ -281,6 +281,32 @@ public class TempoServiceTest {
         Assertions.assertTrue(hasUpdates);
     }
 
+    /**
+     * Mocks the checks that happen when determining if a valid update has arrived for an existing cohort.
+     * @throws Exception
+     */
+    @Test
+    public void testUpdateProvisionalCohortToDelivered() throws Exception {
+        CohortCompleteJson ccJson = getCohortEventData("mockCohortCompleteCCSPPPQQQQ");
+        Cohort provisionalCohort = new Cohort(ccJson);
+        provisionalCohort.setCohortStatus("PROVISIONAL");
+        cohortCompleteService.saveCohort(provisionalCohort, ccJson.getTumorNormalPairsAsSet());
+        Cohort savedCohort = cohortCompleteService.getCohortByCohortId("CCS_PPPQQQQ");
+        Assertions.assertEquals("PROVISIONAL", savedCohort.getCohortStatus());
+
+        CohortCompleteJson ccJsonUpdate = getCohortEventData("mockCohortCompleteCCSPPPQQQQUpdated");
+        Cohort updatedCohort = new Cohort(ccJsonUpdate);
+        updatedCohort.setCohortStatus("DELIVERED");
+        savedCohort.addCohortComplete(updatedCohort.getLatestCohortComplete());
+
+        Boolean hasUpdates = cohortCompleteService.hasUpdates(savedCohort, updatedCohort);
+        Assertions.assertTrue(hasUpdates);
+        savedCohort.setCohortStatus("DELIVERED");
+        cohortCompleteService.saveCohort(savedCohort, updatedCohort.getCohortSamplePrimaryIds());
+        Cohort cohortAfterUpdate = cohortCompleteService.getCohortByCohortId("CCS_PPPQQQQ");
+        Assertions.assertEquals("DELIVERED", cohortAfterUpdate.getCohortStatus());
+    }
+
     @Test
     public void testPopulatingTempoDataNoInitialRunDate() throws Exception {
         // using a tumor sample to trigger population of tempo data

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -73,6 +73,7 @@ tempo.sample_billing_topic=
 tempo.update_samples_embargo_topic=
 tempo.update_cohort_sub_topic=
 tempo.update_cohort_pub_topic=
+tempo.provisional_cohort_sub_topic=
 
 # dbgap topics
 num.dbgap_msg_handler_threads=


### PR DESCRIPTION
# Support provisional cohorts in SMILE

Briefly describe changes proposed in this pull request:
- Schema changes:
  - added `cohortStatus` property to `Cohort` node and `CohortCompleteJson` model
  - added step in `scripts/migrate.cypher` to add new `cohortStatus` property to `Cohort` node
- Checks to changes in `cohortStatus` would be considered a valid update for the database
- Message handlers:
  - added message handler to subscribe to `TEMPO_PROVISIONAL_COHORT_SUB_TOPIC`
  - cohorts delivered to here will set `cohortStatus=PROVISIONAL`
  - cohorts delivered to the `TEMPO_WES_COHORT_COMPLETE_TOPIC` will set `cohortStatus=DELIVERED` 
- Tests:
  - added unit test for importing a provisional cohort along with a test that verifies changes to the `cohortStatus` are recognized and the update will propagate to the db accordingly
- Other:
  - Fixed a bug with how an initial pipeline run date is calculated and set when dealing with provisional cohort samples

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Code checks:**
- [x] Endpoints were tested to ensure their integrity.
- [x] Unit tests were updated in relation to updates to the mocked test data.

If no unit tests were updated or added, then please explain why: [insert details here]

### II. Neo4j models and database schema checklist:
- [x] Neo4j persistence models were changed.
- [x] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]

<img width="477" height="236" alt="image" src="https://github.com/user-attachments/assets/abf94831-602c-4bc1-9834-43522a4e06ea" />


### III. Message handlers checklist:
- [x] Changes in this PR affect the workflow of incoming messages.
- [x] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.

Please describe how the workflow and messaging was tested/simulated:

**1. Testing import of a provisional cohort**

```
[ Pub | Provisional Cohort ] -> [ MsgHandler | TEMPO_PROVISIONAL_COHORT_SUB_TOPIC ] -> [ db | cohortStatus=PROVISIONAL ]
```

**2. Testing update of provisional cohort to cohortStatus=DELIVERED**
```
First:

[ Pub | Provisional Cohort ] -> [ MsgHandler | TEMPO_PROVISIONAL_COHORT_SUB_TOPIC ] -> [ db | cohortStatus=PROVISIONAL ]

Then:
[ Pub | DeliveredCohort ] -> [ MsgHandler | TEMPO_WES_COHORT_COMPLETE_TOPIC ] -> [ db | cohortStatus=DELIVERED ]

```



**Describe your testing environment:**

- NATS: dev server
- Neo4j: dev server
- SMILE Server: dev server
- Message publishing simulation: smile publisher tool

### IV. Configuration and/or permissions checklist:
- [x] New topics were introduced.
- [x] The topics and appropriate permissions were updated in [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] ~~If applicable, a new account was set up and the account credentials and keys are checked into [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).~~
- [ ] ~~Account credentials and keys were shared with the appropriate parties.~~

---
### Screenshots

Logs when provisional cohort is published to the cohort complete topic (meaning the cohort is officially delivered by TEMPO)
<img width="1034" height="340" alt="image" src="https://github.com/user-attachments/assets/2b86b9f9-89b8-4d22-949a-b54e1167e913" />


---
### General checklist:
- [ ] All requested changes and comments have been resolved.

