### PR TITLE
Consolidated cohortStatus and status

### DIFF
--- a/model/src/main/java/org/mskcc/smile/model/tempo/Cohort.java
+++ b/model/src/main/java/org/mskcc/smile/model/tempo/Cohort.java
@@ -24,7 +24,6 @@ public class Cohort implements Serializable {
     @Id @GeneratedValue
     private Long id;
     private String cohortId;
-    private String cohortStatus;
     @Relationship(type = "HAS_COHORT_COMPLETE", direction = Relationship.Direction.OUTGOING)
     private List<CohortComplete> cohortCompleteList;
     @Relationship(type = "HAS_COHORT_SAMPLE", direction = Relationship.Direction.OUTGOING)
@@ -38,7 +37,6 @@ public class Cohort implements Serializable {
      */
     public Cohort(CohortCompleteJson ccJson) {
         this.cohortId = ccJson.getCohortId();
-        this.cohortStatus = ccJson.getCohortStatus();
         addCohortComplete(new CohortComplete(ccJson));
     }
 
@@ -56,14 +54,6 @@ public class Cohort implements Serializable {
 
     public void setCohortId(String cohortId) {
         this.cohortId = cohortId;
-    }
-
-    public String getCohortStatus() {
-        return cohortStatus;
-    }
-
-    public void setCohortStatus(String cohortStatus) {
-        this.cohortStatus = cohortStatus;
     }
 
     /**

--- a/model/src/main/java/org/mskcc/smile/model/tempo/json/CohortCompleteJson.java
+++ b/model/src/main/java/org/mskcc/smile/model/tempo/json/CohortCompleteJson.java
@@ -36,7 +36,6 @@ public class CohortCompleteJson implements Serializable {
     private String status;
     @JsonProperty("pipelineVersion")
     private String pipelineVersion;
-    private String cohortStatus;
 
     public CohortCompleteJson() {}
 
@@ -149,14 +148,6 @@ public class CohortCompleteJson implements Serializable {
             }
         }
         return primaryIds;
-    }
-
-    public String getCohortStatus() {
-        return cohortStatus;
-    }
-
-    public void setCohortStatus(String cohortStatus) {
-        this.cohortStatus = cohortStatus;
     }
 
     @Override

--- a/service/src/main/java/org/mskcc/smile/service/impl/CohortCompleteServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/CohortCompleteServiceImpl.java
@@ -10,6 +10,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.mskcc.smile.commons.JsonComparator;
 import org.mskcc.smile.model.tempo.Cohort;
+import org.mskcc.smile.model.tempo.CohortComplete;
 import org.mskcc.smile.persistence.neo4j.CohortCompleteRepository;
 import org.mskcc.smile.service.CohortCompleteService;
 import org.mskcc.smile.service.SmileSampleService;
@@ -44,10 +45,6 @@ public class CohortCompleteServiceImpl implements CohortCompleteService {
     @Override
     @Transactional(rollbackFor = {Exception.class})
     public void saveCohort(Cohort cohort, Set<String> sampleIds) throws Exception {
-        if (StringUtils.isBlank(cohort.getCohortStatus())) {
-            cohort.setCohortStatus("DELIVERED");
-        }
-
         // persist new cohort complete event to the db
         cohortCompleteRepository.save(cohort);
         if (sampleIds == null || sampleIds.isEmpty()) {
@@ -158,10 +155,13 @@ public class CohortCompleteServiceImpl implements CohortCompleteService {
         if (hasCohortCompleteUpdates(existingCohort, cohort)) {
             return Boolean.TRUE;
         }
-        // check for change in cohort status
-        if (!StringUtils.isBlank(existingCohort.getCohortStatus())
-                && !StringUtils.isBlank(cohort.getCohortStatus())
-                && !existingCohort.getCohortStatus().equals(cohort.getCohortStatus())) {
+        // check for change in status of the latest cohort complete event
+        CohortComplete existingLatest = existingCohort.getLatestCohortComplete();
+        CohortComplete incomingLatest = cohort.getLatestCohortComplete();
+        if (existingLatest != null && incomingLatest != null
+                && !StringUtils.isBlank(existingLatest.getStatus())
+                && !StringUtils.isBlank(incomingLatest.getStatus())
+                && !existingLatest.getStatus().equals(incomingLatest.getStatus())) {
             return Boolean.TRUE;
         }
         // check for change in cohort samples list

--- a/service/src/main/java/org/mskcc/smile/service/impl/TempoMessageHandlingServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/TempoMessageHandlingServiceImpl.java
@@ -316,7 +316,6 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                         } else if (cohortCompleteService.hasUpdates(existingCohort,
                                 cohort)) {
                             LOG.info("Received updates for cohort: " + ccJson.getCohortId());
-                            existingCohort.setCohortStatus("DELIVERED");
                             if (cohortCompleteService.hasCohortCompleteUpdates(existingCohort, cohort)) {
                                 existingCohort.addCohortComplete(cohort.getLatestCohortComplete());
                             }
@@ -1026,7 +1025,6 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                     CohortCompleteJson cohortCompleteData =
                             (CohortCompleteJson) NatsMsgUtil.convertObjectFromString(
                                     cohortCompleteJson, new TypeReference<CohortCompleteJson>() {});
-                    cohortCompleteData.setCohortStatus("DELIVERED");
                     tempoMessageHandlingService.cohortCompleteHandler(cohortCompleteData);
                 } catch (Exception e) {
                     LOG.error("Exception occurred during processing of Cohort Complete event: "
@@ -1125,7 +1123,6 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                     }
                     CohortCompleteJson ccJson = (CohortCompleteJson) NatsMsgUtil.convertObjectFromString(
                                     ccJsonString, new TypeReference<CohortCompleteJson>() {});
-                    ccJson.setCohortStatus("DELIVERED");
                     tempoMessageHandlingService.updateTempoCohortHandler(ccJson);
                 } catch (Exception e) {
                     LOG.error("Exception occurred during processing of TEMPO "
@@ -1150,7 +1147,7 @@ public class TempoMessageHandlingServiceImpl implements TempoMessageHandlingServ
                     }
                     CohortCompleteJson ccJson = (CohortCompleteJson) NatsMsgUtil.convertObjectFromString(
                                     ccJsonString, new TypeReference<CohortCompleteJson>() {});
-                    ccJson.setCohortStatus("PROVISIONAL");
+                    ccJson.setStatus("PROVISIONAL");
                     tempoMessageHandlingService.provisionalCohortHandler(ccJson);
                 } catch (Exception e) {
                     LOG.error("Exception occurred during processing of provisional TEMPO "

--- a/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
+++ b/service/src/test/java/org/mskcc/smile/service/TempoServiceTest.java
@@ -288,23 +288,21 @@ public class TempoServiceTest {
     @Test
     public void testUpdateProvisionalCohortToDelivered() throws Exception {
         CohortCompleteJson ccJson = getCohortEventData("mockCohortCompleteCCSPPPQQQQ");
+        ccJson.setStatus("PROVISIONAL");
         Cohort provisionalCohort = new Cohort(ccJson);
-        provisionalCohort.setCohortStatus("PROVISIONAL");
         cohortCompleteService.saveCohort(provisionalCohort, ccJson.getTumorNormalPairsAsSet());
         Cohort savedCohort = cohortCompleteService.getCohortByCohortId("CCS_PPPQQQQ");
-        Assertions.assertEquals("PROVISIONAL", savedCohort.getCohortStatus());
+        Assertions.assertEquals("PROVISIONAL", savedCohort.getLatestCohortComplete().getStatus());
 
         CohortCompleteJson ccJsonUpdate = getCohortEventData("mockCohortCompleteCCSPPPQQQQUpdated");
         Cohort updatedCohort = new Cohort(ccJsonUpdate);
-        updatedCohort.setCohortStatus("DELIVERED");
-        savedCohort.addCohortComplete(updatedCohort.getLatestCohortComplete());
 
         Boolean hasUpdates = cohortCompleteService.hasUpdates(savedCohort, updatedCohort);
         Assertions.assertTrue(hasUpdates);
-        savedCohort.setCohortStatus("DELIVERED");
+        savedCohort.addCohortComplete(updatedCohort.getLatestCohortComplete());
         cohortCompleteService.saveCohort(savedCohort, updatedCohort.getCohortSamplePrimaryIds());
         Cohort cohortAfterUpdate = cohortCompleteService.getCohortByCohortId("CCS_PPPQQQQ");
-        Assertions.assertEquals("DELIVERED", cohortAfterUpdate.getCohortStatus());
+        Assertions.assertEquals("PASS", cohortAfterUpdate.getLatestCohortComplete().getStatus());
     }
 
     @Test


### PR DESCRIPTION
Consolidated use of Cohort.cohortStatus and CohortComplete.status
- removed use of Cohort.cohortStatus and switched to use of CohortComplete.status
- updated unit tests accordingly

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Web service and data model checklist

Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Code checks:**
- [ ] Endpoints were tested to ensure their integrity.
- [x] Unit tests were updated in relation to updates to the mocked test data.

If no unit tests were updated or added, then please explain why: [insert details here]

### II. Neo4j models and database schema checklist:
- [x] Neo4j persistence models were changed.
- [x] The graph database produces the expected changes to models, relationships, and/or property names. [provide screenshot of updated elements in graph db below]

### III. Message handlers checklist:
- [ ] Changes in this PR affect the workflow of incoming messages.
- [x] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS: dev server
- Neo4j: dev server
- SMILE Server:  dev server
- Message publishing simulation: smile dashboard

